### PR TITLE
[test] 가게 API 테스트코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ out/
 
 ## 환경 설정 파일
 .env
+.env.*
 
 ## QueryDSL Q Class
 /src/main/generated/

--- a/src/main/java/org/example/tablenow/domain/store/dto/request/StoreCreateRequestDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/request/StoreCreateRequestDto.java
@@ -3,12 +3,15 @@ package org.example.tablenow.domain.store.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.tablenow.domain.store.validation.annotation.HalfHourOnly;
 
 import java.time.LocalTime;
 
 @Getter
+@NoArgsConstructor
 public class StoreCreateRequestDto {
     @NotBlank
     private String name;
@@ -29,4 +32,17 @@ public class StoreCreateRequestDto {
     private Integer deposit;
     @NotNull
     private Long categoryId;
+
+    @Builder
+    private StoreCreateRequestDto(String name, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit, Long categoryId) {
+        this.name = name;
+        this.description = description;
+        this.address = address;
+        this.imageUrl = imageUrl;
+        this.capacity = capacity;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.deposit = deposit;
+        this.categoryId = categoryId;
+    }
 }

--- a/src/main/java/org/example/tablenow/domain/store/dto/request/StoreUpdateRequestDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/request/StoreUpdateRequestDto.java
@@ -3,12 +3,15 @@ package org.example.tablenow.domain.store.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.tablenow.domain.store.validation.annotation.HalfHourOnly;
 
 import java.time.LocalTime;
 
 @Getter
+@NoArgsConstructor
 public class StoreUpdateRequestDto {
     private String name;
     private String description;
@@ -23,4 +26,17 @@ public class StoreUpdateRequestDto {
     @Min(0)
     private Integer deposit;
     private Long categoryId;
+
+    @Builder
+    private StoreUpdateRequestDto(String name, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit, Long categoryId) {
+        this.name = name;
+        this.description = description;
+        this.address = address;
+        this.imageUrl = imageUrl;
+        this.capacity = capacity;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.deposit = deposit;
+        this.categoryId = categoryId;
+    }
 }

--- a/src/main/java/org/example/tablenow/domain/store/enums/StoreSortField.java
+++ b/src/main/java/org/example/tablenow/domain/store/enums/StoreSortField.java
@@ -3,7 +3,6 @@ package org.example.tablenow.domain.store.enums;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
-import org.apache.coyote.BadRequestException;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
 
@@ -45,4 +44,14 @@ public enum StoreSortField {
         }
         throw new HandledException(ErrorCode.BAD_REQUEST);
     }
+
+    public static String fromString(String property) {
+        for (StoreSortField field : values()) {
+            if (field.property.equals(property)) {
+                return field.property;
+            }
+        }
+        throw new HandledException(ErrorCode.INVALID_SORT_FIELD);
+    }
+
 }

--- a/src/main/java/org/example/tablenow/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/example/tablenow/domain/store/repository/StoreRepository.java
@@ -3,5 +3,8 @@ package org.example.tablenow.domain.store.repository;
 import org.example.tablenow.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreQueryRepository {
+    Optional<Store> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -41,7 +41,8 @@ public enum ErrorCode {
     RESERVATION_STATUS_INVALID(HttpStatus.BAD_REQUEST, "예약 상태가 유효하지 않습니다."),
     RESERVATION_STATUS_UPDATE_FORBIDDEN(HttpStatus.BAD_REQUEST, "예약 상태에서만 변경할 수 있습니다."),
 
-
+    INVALID_SORT_FIELD(HttpStatus.BAD_REQUEST, "정렬 필드가 잘못되었습니다."),
+    INVALID_ORDER_VALUE(HttpStatus.BAD_REQUEST, "정렬 옵션이 잘못되었습니다. 오름차순(asc) 또는 내림차순(desc)을 선택해주세요."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,12 +1,21 @@
 spring:
   config:
-    import: optional:file:.env[.properties]
-
+    import: optional:file:.env.local[.properties]
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
   data:
     redis:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,12 +1,21 @@
 spring:
   config:
-    import: optional:file:.env[.properties]
-
+    import: optional:file:.env.test[.properties]
   datasource:
-    url: ${TEST_DB_URL}
+    url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+        dialect: org.hibernate.dialect.MySQLDialect
 
   data:
     redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,15 +2,8 @@ spring:
   application:
     name: table-now
 
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-        use_sql_comments: true
-        dialect: org.hibernate.dialect.MySQLDialect
+  config:
+    import: optional:file:.env[.properties]
 
 jwt:
   secret:


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #26

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
가게 서비스 테스트코드 작성 및 기존 로직 코드 개선 
- [X] 가게 등록 테스트코드
- `예외`: 존재하지 않는 카테고리, 시작-마감시간 오류, 최대 등록수 초과
- `성공`
- [X] 내 가게 목록 조회 테스트코드
- `성공`
- [X] 가게 수정
- `예외`: 존재하지 않는 가게, 가게 주인이 아닌 경우, 존재하지 않는 카테고리, 시작-마감시간 오류
- `성공`: 요청 데이터가 비어있는 경우
- [X] 가게 삭제
- `예외`: 존재하지 않는 가게, 가게 주인이 아닌 경우
- `성공`
- [X] 가게 목록 조회
- `예외`: 정렬 옵션 오류, 정렬 기준 오류 
- `성공`: 검색어 제외 조회
- [X] 가게 정보 조회
- `예외`: 존재하지 않는 가게
- `성공`
- [X] 가게 인기 검색 랭킹
- `성공`: 캐시 키 초기화, 존재하지 않는 캐시 내부 데이터 

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
* 테스트 커버리지
![image](https://github.com/user-attachments/assets/be3a0037-3f0b-4ddb-a66d-c3124eac0966)
