### PR TITLE
[feat] 이벤트 오픈 스케줄러 구현 및 이벤트 참여 API 구현

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/controller/EventController.java
+++ b/src/main/java/org/example/tablenow/domain/event/controller/EventController.java
@@ -7,7 +7,7 @@ import org.example.tablenow.domain.event.dto.request.EventRequestDto;
 import org.example.tablenow.domain.event.dto.request.EventUpdateRequestDto;
 import org.example.tablenow.domain.event.dto.response.EventDeleteResponseDto;
 import org.example.tablenow.domain.event.dto.response.EventResponseDto;
-import org.example.tablenow.domain.event.entity.EventStatus;
+import org.example.tablenow.domain.event.enums.EventStatus;
 import org.example.tablenow.domain.event.service.EventService;
 import org.example.tablenow.domain.user.enums.UserRole;
 import org.springframework.data.domain.Page;

--- a/src/main/java/org/example/tablenow/domain/event/controller/EventJoinController.java
+++ b/src/main/java/org/example/tablenow/domain/event/controller/EventJoinController.java
@@ -1,0 +1,28 @@
+package org.example.tablenow.domain.event.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.domain.event.dto.response.EventJoinResponseDto;
+import org.example.tablenow.domain.event.service.EventJoinService;
+import org.example.tablenow.global.dto.AuthUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class EventJoinController {
+
+    private final EventJoinService eventJoinService;
+
+    @PostMapping("/v1/events/{eventId}/join")
+    public ResponseEntity<EventJoinResponseDto> joinEvent(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable Long eventId
+    ) {
+        return ResponseEntity.ok(eventJoinService.joinEvent(eventId, authUser));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventJoinResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventJoinResponseDto.java
@@ -1,0 +1,42 @@
+package org.example.tablenow.domain.event.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.tablenow.domain.event.entity.EventJoin;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class EventJoinResponseDto {
+    private final Long eventJoinId;
+    private final Long eventId;
+    private final Long storeId;
+    private final String storeName;
+    private final LocalDateTime eventTime;
+    private final LocalDateTime joinedAt;
+    private final String message;
+
+    @Builder
+    private EventJoinResponseDto(Long eventJoinId, Long eventId, Long storeId,
+                                String storeName, LocalDateTime eventTime, LocalDateTime joinedAt, String message) {
+        this.eventJoinId = eventJoinId;
+        this.eventId = eventId;
+        this.storeId = storeId;
+        this.storeName = storeName;
+        this.eventTime = eventTime;
+        this.joinedAt = joinedAt;
+        this.message = message;
+    }
+
+    public static EventJoinResponseDto fromEventJoin(EventJoin eventJoin) {
+        return EventJoinResponseDto.builder()
+                .eventJoinId(eventJoin.getId())
+                .eventId(eventJoin.getEvent().getId())
+                .storeId(eventJoin.getEvent().getStore().getId())
+                .storeName(eventJoin.getEvent().getStore().getName())
+                .eventTime(eventJoin.getEvent().getEventTime())
+                .joinedAt(eventJoin.getJoinedAt())
+                .message("이벤트 예약에 성공했습니다.")
+                .build();
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventResponseDto.java
@@ -3,7 +3,7 @@ package org.example.tablenow.domain.event.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.tablenow.domain.event.entity.Event;
-import org.example.tablenow.domain.event.entity.EventStatus;
+import org.example.tablenow.domain.event.enums.EventStatus;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/org/example/tablenow/domain/event/entity/Event.java
+++ b/src/main/java/org/example/tablenow/domain/event/entity/Event.java
@@ -56,6 +56,10 @@ public class Event extends TimeStamped {
         if (limitPeople != null) this.limitPeople = limitPeople;
     }
 
+    public void changeStatus(EventStatus status) {
+        this.status = status;
+    }
+
     public static Event create(Store store, EventRequestDto dto) {
         return Event.builder()
                 .store(store)

--- a/src/main/java/org/example/tablenow/domain/event/entity/Event.java
+++ b/src/main/java/org/example/tablenow/domain/event/entity/Event.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tablenow.domain.event.dto.request.EventRequestDto;
+import org.example.tablenow.domain.event.enums.EventStatus;
 import org.example.tablenow.domain.store.entity.Store;
 import org.example.tablenow.global.entity.TimeStamped;
 

--- a/src/main/java/org/example/tablenow/domain/event/entity/EventJoin.java
+++ b/src/main/java/org/example/tablenow/domain/event/entity/EventJoin.java
@@ -1,0 +1,45 @@
+package org.example.tablenow.domain.event.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.tablenow.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "event_join")
+@NoArgsConstructor
+public class EventJoin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "is_notified", nullable = false)
+    private boolean isNotified = false;
+
+    @Builder
+    public EventJoin(User user, Event event) {
+        this.user = user;
+        this.event = event;
+        this.joinedAt = LocalDateTime.now();
+        this.isNotified = false;
+    }
+
+    public void markNotified() {
+        this.isNotified = true;
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/enums/EventStatus.java
+++ b/src/main/java/org/example/tablenow/domain/event/enums/EventStatus.java
@@ -1,4 +1,4 @@
-package org.example.tablenow.domain.event.entity;
+package org.example.tablenow.domain.event.enums;
 
 public enum EventStatus {
     READY, OPENED, CLOSED

--- a/src/main/java/org/example/tablenow/domain/event/repository/EventJoinRepository.java
+++ b/src/main/java/org/example/tablenow/domain/event/repository/EventJoinRepository.java
@@ -1,0 +1,11 @@
+package org.example.tablenow.domain.event.repository;
+
+import org.example.tablenow.domain.event.entity.Event;
+import org.example.tablenow.domain.event.entity.EventJoin;
+import org.example.tablenow.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventJoinRepository extends JpaRepository<EventJoin, Long> {
+    boolean existsByUserAndEvent(User user, Event event);
+    int countByEvent(Event event);
+}

--- a/src/main/java/org/example/tablenow/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/example/tablenow/domain/event/repository/EventRepository.java
@@ -7,9 +7,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
     boolean existsByStoreIdAndEventTime(Long storeId, LocalDateTime eventTime);
-
     Page<Event> findByStatus(EventStatus status, Pageable pageable);
+    List<Event> findAllByStatusAndOpenAtLessThanEqual(EventStatus status, LocalDateTime now);
 }

--- a/src/main/java/org/example/tablenow/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/example/tablenow/domain/event/repository/EventRepository.java
@@ -1,7 +1,7 @@
 package org.example.tablenow.domain.event.repository;
 
 import org.example.tablenow.domain.event.entity.Event;
-import org.example.tablenow.domain.event.entity.EventStatus;
+import org.example.tablenow.domain.event.enums.EventStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
@@ -1,0 +1,46 @@
+package org.example.tablenow.domain.event.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.domain.event.dto.response.EventJoinResponseDto;
+import org.example.tablenow.domain.event.entity.Event;
+import org.example.tablenow.domain.event.entity.EventJoin;
+import org.example.tablenow.domain.event.enums.EventStatus;
+import org.example.tablenow.domain.event.repository.EventJoinRepository;
+import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventJoinService {
+
+    private final EventJoinRepository eventJoinRepository;
+    private final EventService eventService;
+
+    public EventJoinResponseDto joinEvent(Long eventId, AuthUser authUser) {
+        User user = User.fromAuthUser(authUser);
+        Event event = eventService.getEvent(eventId);
+
+        if (event.getStatus() != EventStatus.OPENED) {
+            throw new HandledException(ErrorCode.EVENT_NOT_OPENED);
+        }
+
+        if (eventJoinRepository.existsByUserAndEvent(user, event)) {
+            throw new HandledException(ErrorCode.EVENT_ALREADY_JOINED);
+        }
+
+        if (eventJoinRepository.countByEvent(event) >= event.getLimitPeople()) {
+            throw new HandledException(ErrorCode.EVENT_FULL);
+        }
+
+        EventJoin eventJoin = EventJoin.builder()
+                .user(user)
+                .event(event)
+                .build();
+        eventJoinRepository.save(eventJoin);
+
+        return EventJoinResponseDto.fromEventJoin(eventJoin);
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/service/EventOpenScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventOpenScheduler.java
@@ -1,0 +1,19 @@
+package org.example.tablenow.domain.event.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventOpenScheduler {
+    private final EventService eventService;
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void runEventOpenScheduler() {
+        log.info("🕒 이벤트 스케줄러 실행됨!");
+        eventService.openEventsIfDue();
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/service/EventService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventService.java
@@ -1,6 +1,7 @@
 package org.example.tablenow.domain.event.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.event.dto.request.EventRequestDto;
 import org.example.tablenow.domain.event.dto.request.EventUpdateRequestDto;
 import org.example.tablenow.domain.event.dto.response.EventDeleteResponseDto;
@@ -18,6 +19,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventService {
@@ -77,6 +82,17 @@ public class EventService {
 
         eventRepository.delete(event);
         return EventDeleteResponseDto.fromEvent(event);
+    }
+
+    @Transactional
+    public void openEventsIfDue() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Event> eventsToOpen = eventRepository.findAllByStatusAndOpenAtLessThanEqual(EventStatus.READY, now);
+
+        for (Event event : eventsToOpen) {
+            event.changeStatus(EventStatus.OPENED);
+            log.info("이벤트 오픈됨: id={}, store={}, openAt={}", event.getId(), event.getStore().getName(), event.getOpenAt());
+        }
     }
 
     protected Event getEvent(Long id) {

--- a/src/main/java/org/example/tablenow/domain/event/service/EventService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventService.java
@@ -6,7 +6,7 @@ import org.example.tablenow.domain.event.dto.request.EventUpdateRequestDto;
 import org.example.tablenow.domain.event.dto.response.EventDeleteResponseDto;
 import org.example.tablenow.domain.event.dto.response.EventResponseDto;
 import org.example.tablenow.domain.event.entity.Event;
-import org.example.tablenow.domain.event.entity.EventStatus;
+import org.example.tablenow.domain.event.enums.EventStatus;
 import org.example.tablenow.domain.event.repository.EventRepository;
 import org.example.tablenow.domain.store.entity.Store;
 import org.example.tablenow.domain.store.service.StoreService;

--- a/src/main/java/org/example/tablenow/global/config/SchedulingConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package org.example.tablenow.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -45,6 +45,10 @@ public enum ErrorCode {
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트가 존재하지 않습니다."),
     EVENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 시간에 이벤트가 존재합니다."),
     INVALID_EVENT_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서는 해당 작업을 수행할 수 없습니다."),
+    EVENT_NOT_OPENED(HttpStatus.BAD_REQUEST, "현재 신청할 수 있는 이벤트가 아닙니다."),
+    EVENT_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 해당 이벤트에 참가하였습니다."),
+    EVENT_FULL(HttpStatus.BAD_REQUEST, "이벤트 정원이 초과되었습니다."),
+
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #35 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 이벤트 참여 내역을 관리하는 `EventJoin` 엔티티 생성
- [X] `joinEvent()` 메서드 구현
- [X] 이벤트 참여 관련 예외 케이스 검증 
- [X] 1분 마다 이벤트 상태를 체크하는 `EventOpenScheduler` 구현
- [X] 이벤트 관련 예외 메세지 추가

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
기술 고도화 진행 시 Redis ZSet과 MQ로 전환 예정입니다.

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/95e17983-6f88-4df5-bc43-c55846ba2f8c)
