### PR TITLE
[test] 카테고리 API 테스트코드 작성

### DIFF
--- a/src/main/java/org/example/tablenow/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/tablenow/domain/category/service/CategoryService.java
@@ -24,7 +24,7 @@ public class CategoryService {
 
     @Transactional
     public CategoryResponseDto saveCategory(CategoryRequestDto requestDto) {
-        findCategoryByName(requestDto.getName()).ifPresent(category -> {
+        findCategoryByName(requestDto.getName()).ifPresent(it -> {
             throw new HandledException(ErrorCode.CATEGORY_ALREADY_EXISTS);
         });
         Category category = Category.builder().name(requestDto.getName()).build();
@@ -35,6 +35,9 @@ public class CategoryService {
     @Transactional
     public CategoryResponseDto updateCategory(Long id, CategoryRequestDto requestDto) {
         Category category = findCategory(id);
+        findCategoryByName(requestDto.getName()).ifPresent(it -> {
+            throw new HandledException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        });
         category.updateName(requestDto.getName());
         return CategoryResponseDto.fromCategory(category);
     }

--- a/src/test/java/org/example/tablenow/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,173 @@
+package org.example.tablenow.domain.category.service;
+
+import org.example.tablenow.domain.category.dto.request.CategoryRequestDto;
+import org.example.tablenow.domain.category.dto.response.CategoryDeleteResponseDto;
+import org.example.tablenow.domain.category.dto.response.CategoryResponseDto;
+import org.example.tablenow.domain.category.entity.Category;
+import org.example.tablenow.domain.category.repository.CategoryRepository;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.swing.*;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+    @InjectMocks
+    private CategoryService categoryService;
+
+    Long categoryId = 1L;
+    String categoryName = "한식";
+    Category category = Category.builder().id(categoryId).name(categoryName).build();
+
+    @Nested
+    class 카테고리_등록 {
+        CategoryRequestDto dto = new CategoryRequestDto();
+
+        @BeforeEach
+        void setUp() {
+            ReflectionTestUtils.setField(dto, "name", categoryName);
+        }
+
+        @Test
+        void 중복_카테고리_등록_시_예외_발생() {
+            // given
+            given(categoryRepository.findByName(anyString())).willReturn(Optional.of(category));
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    categoryService.saveCategory(dto)
+            );
+            assertEquals(exception.getMessage(), ErrorCode.CATEGORY_ALREADY_EXISTS.getDefaultMessage());
+        }
+
+        @Test
+        void 등록_성공() {
+            // given
+            given(categoryRepository.findByName(anyString())).willReturn(Optional.empty());
+            given(categoryRepository.save(any(Category.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            CategoryResponseDto response = categoryService.saveCategory(dto);
+
+            // then
+            assertNotNull(response);
+            assertEquals(response.getName(), categoryName);
+        }
+    }
+
+    @Nested
+    class 카테고리_수정 {
+        CategoryRequestDto dto = new CategoryRequestDto();
+
+        @Test
+        void 존재하지_않는_카테고리_조회_시_예외_발생() {
+            // given
+            given(categoryRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    categoryService.updateCategory(categoryId, dto)
+            );
+            assertEquals(exception.getMessage(), ErrorCode.CATEGORY_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 중복_카테고리_등록_시_예외_발생() {
+            // given
+            ReflectionTestUtils.setField(dto, "name", categoryName);
+            given(categoryRepository.findById(anyLong())).willReturn(Optional.of(category));
+            given(categoryRepository.findByName(anyString())).willReturn(Optional.of(category));
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    categoryService.updateCategory(categoryId, dto)
+            );
+            assertEquals(exception.getMessage(), ErrorCode.CATEGORY_ALREADY_EXISTS.getDefaultMessage());
+        }
+
+        @Test
+        void 수정_성공() {
+            // given
+            String requestName = "분식";
+            ReflectionTestUtils.setField(dto, "name", requestName);
+            given(categoryRepository.findById(anyLong())).willReturn(Optional.of(category));
+            given(categoryRepository.findByName(anyString())).willReturn(Optional.empty());
+
+            // when
+            CategoryResponseDto response = categoryService.updateCategory(categoryId, dto);
+
+            // then
+            assertNotNull(response);
+            assertEquals(response.getName(), requestName);
+        }
+    }
+
+    @Nested
+    class 카테고리_삭제 {
+        @Test
+        void 존재하지_않는_카테고리_조회_시_예외_발생() {
+            // given
+            given(categoryRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    categoryService.deleteCategory(categoryId)
+            );
+            assertEquals(exception.getMessage(), ErrorCode.CATEGORY_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 삭제_성공() {
+            // given
+            given(categoryRepository.findById(anyLong())).willReturn(Optional.of(category));
+
+            // when
+            CategoryDeleteResponseDto response = categoryService.deleteCategory(categoryId);
+
+            // then
+            assertNotNull(response);
+            assertEquals(response.getId(), categoryId);
+        }
+    }
+
+    @Nested
+    class 카테고리_목록_조회 {
+        Category category1 = Category.builder().id(1L).name(categoryName).build();
+        Category category2 = Category.builder().id(2L).name("중식").build();
+        Category category3 = Category.builder().id(3L).name("일식").build();
+        List<Category> categories = List.of(category1, category2, category3);
+
+        @Test
+        void 조회_성공() {
+            // given
+            given(categoryRepository.findAll(any(Sort.class))).willReturn(categories);
+
+            // when
+            List<CategoryResponseDto> response = categoryService.findAllCategories();
+
+            // then
+            assertNotNull(response);
+            assertEquals(response.size(), categories.size());
+            assertEquals(response.get(0).getName(), categoryName);
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #45 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
카테고리 서비스 테스트코드 작성 및 기존 로직 코드 개선
* `수정` : 카테고리 수정 시 기존 카테고리 목록에서 중복 카테고리명 확인

- [X] 카테고리 등록
> `예외`: 중복 카테고리 등록
`성공`
- [X] 카테고리 수정
> `예외`: 존재하지 않는 카테고리 수정, 중복 카테고리명으로 수정
`성공`
- [X] 카테고리 삭제
> `예외`: 존재하지 않는 카테고리 삭제
`성공`
- [X] 카테고리 목록 조회
> `성공`


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
* 테스트 커버리지
![image](https://github.com/user-attachments/assets/b193a900-0a77-46fe-9ec8-d5e9f863bb57)

