### PR TITLE
[refactor] 유저 API 리팩토링

### DIFF
--- a/src/main/java/org/example/tablenow/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/tablenow/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.example.tablenow.domain.auth.service.NaverAuthService;
 import org.example.tablenow.domain.auth.dto.response.SignupResponse;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.example.tablenow.global.util.CookieUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -65,15 +66,7 @@ public class AuthController {
         if (refreshToken != null) {
             authService.logout(refreshToken);
         }
-
-        // 쿠키에서 리프레시 토큰 제거
-        Cookie cookie = new Cookie("refreshToken", null);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-
+        CookieUtil.deleteRefreshTokenCookie(response);
         return ResponseEntity.ok("로그아웃에 성공했습니다.");
     }
 

--- a/src/main/java/org/example/tablenow/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/tablenow/domain/user/controller/UserController.java
@@ -1,16 +1,16 @@
 package org.example.tablenow.domain.user.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.tablenow.domain.user.dto.request.UpdatePasswordRequest;
 import org.example.tablenow.domain.user.dto.request.UpdateProfileRequest;
 import org.example.tablenow.domain.user.dto.request.UserDeleteRequest;
-import org.example.tablenow.domain.user.dto.response.UserProfileResponse;
 import org.example.tablenow.domain.user.dto.response.SimpleUserResponse;
+import org.example.tablenow.domain.user.dto.response.UserProfileResponse;
 import org.example.tablenow.domain.user.service.UserService;
 import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.util.CookieUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,31 +28,26 @@ public class UserController {
             @Valid @RequestBody UserDeleteRequest request,
             HttpServletResponse response
     ) {
-        // 쿠키에서 리프레시 토큰 제거
-        Cookie cookie = new Cookie("refreshToken", null);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-
+        CookieUtil.deleteRefreshTokenCookie(response);
         return ResponseEntity.ok(userService.deleteUser(authUser, request));
     }
 
-    @PatchMapping("v1/users/password")
+    @PatchMapping("/v1/users/password")
     public ResponseEntity<SimpleUserResponse> updatePassword(
             @AuthenticationPrincipal AuthUser authUser,
-            @Valid @RequestBody UpdatePasswordRequest request
+            @Valid @RequestBody UpdatePasswordRequest request,
+            HttpServletResponse response
     ) {
+        CookieUtil.deleteRefreshTokenCookie(response);
         return ResponseEntity.ok(userService.updatePassword(authUser, request));
     }
 
-    @GetMapping("v1/users")
+    @GetMapping("/v1/users")
     public ResponseEntity<UserProfileResponse> getUserProfile(@AuthenticationPrincipal AuthUser authUser) {
         return ResponseEntity.ok(userService.getUserProfile(authUser));
     }
 
-    @PatchMapping("v1/users")
+    @PatchMapping("/v1/users")
     public ResponseEntity<UserProfileResponse> updateUserProfile(
             @AuthenticationPrincipal AuthUser authUser,
             @Valid @RequestBody UpdateProfileRequest request

--- a/src/main/java/org/example/tablenow/global/util/CookieUtil.java
+++ b/src/main/java/org/example/tablenow/global/util/CookieUtil.java
@@ -1,0 +1,18 @@
+package org.example.tablenow.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtil {
+
+    private CookieUtil() {}
+
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("refreshToken", null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
close #59 


## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 중복된 refreshToken 삭제 로직을 헬퍼 메서드로 분리
- [X] UserService의 사용자 조회 + 비밀번호 검증 로직을 하나의 메서드로 통합
- [X] 프로필 수정 시 공백만 입력된 닉네임/전화번호 무시하도록 검증 방식 개선

## 💡 PR 특이사항
- 피드백 반영했습니다!
