### PR TITLE
[feat] 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // S3
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/example/tablenow/domain/image/controller/ImageController.java
+++ b/src/main/java/org/example/tablenow/domain/image/controller/ImageController.java
@@ -1,0 +1,30 @@
+package org.example.tablenow.domain.image.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.domain.image.dto.request.PresignedUrlRequest;
+import org.example.tablenow.domain.image.dto.response.PresignedUrlResponse;
+import org.example.tablenow.domain.image.enums.ImageDomain;
+import org.example.tablenow.domain.image.service.ImageService;
+import org.example.tablenow.global.dto.AuthUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api")
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping("/v1/images/upload/{domain}")
+    public ResponseEntity<PresignedUrlResponse> generatePresignedUrl(
+            @AuthenticationPrincipal AuthUser authUser,
+            @PathVariable("domain") String domain,
+            @Valid @RequestBody PresignedUrlRequest request
+    ) {
+        ImageDomain imageDomain = ImageDomain.of(domain);
+        return ResponseEntity.ok(imageService.generatePresignedUrl(authUser, imageDomain, request));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/image/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/org/example/tablenow/domain/image/dto/request/PresignedUrlRequest.java
@@ -1,0 +1,22 @@
+package org.example.tablenow.domain.image.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import org.example.tablenow.domain.image.enums.FileType;
+import org.example.tablenow.global.util.RegexConstants;
+
+@Getter
+public class PresignedUrlRequest {
+
+    @NotBlank(message = "파일 이름은 필수입니다.")
+    @Pattern(
+            regexp = RegexConstants.IMAGE_FILE_NAME_REGEX,
+            message = "이미지 파일(jpg, jpeg, png, webp)만 업로드할 수 있습니다."
+    )
+    private String fileName;
+
+    @NotNull(message = "파일 타입은 필수입니다.")
+    private FileType fileType;
+}

--- a/src/main/java/org/example/tablenow/domain/image/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/org/example/tablenow/domain/image/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,16 @@
+package org.example.tablenow.domain.image.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PresignedUrlResponse {
+    private final String uploadUrl;
+    private final String fileUrl;
+
+    @Builder
+    public PresignedUrlResponse(String uploadUrl, String fileUrl) {
+        this.uploadUrl = uploadUrl;
+        this.fileUrl = fileUrl;
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/image/enums/FileType.java
+++ b/src/main/java/org/example/tablenow/domain/image/enums/FileType.java
@@ -1,0 +1,25 @@
+package org.example.tablenow.domain.image.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileType {
+    JPEG("image/jpeg"),
+    PNG("image/png"),
+    WEBP("image/webp");
+
+    private final String mimeType;
+
+    public static FileType of(String mimeType) {
+        return Arrays.stream(values())
+                .filter(f -> f.mimeType.equalsIgnoreCase(mimeType))
+                .findFirst()
+                .orElseThrow(() -> new HandledException(ErrorCode.INVALID_FILE_TYPE, "지원하지 않는 파일 형식입니다: " + mimeType));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/image/enums/ImageDomain.java
+++ b/src/main/java/org/example/tablenow/domain/image/enums/ImageDomain.java
@@ -1,0 +1,17 @@
+package org.example.tablenow.domain.image.enums;
+
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+
+import java.util.Arrays;
+
+public enum ImageDomain {
+    USER, STORE;
+
+    public static ImageDomain of(String domain) {
+        return Arrays.stream(values())
+                .filter(d -> d.name().equalsIgnoreCase(domain))
+                .findFirst()
+                .orElseThrow(() -> new HandledException(ErrorCode.INVALID_IMAGE_DOMAIN, "잘못된 이미지 도메인입니다: " + domain));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/image/service/ImageService.java
+++ b/src/main/java/org/example/tablenow/domain/image/service/ImageService.java
@@ -1,0 +1,61 @@
+package org.example.tablenow.domain.image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.domain.image.dto.request.PresignedUrlRequest;
+import org.example.tablenow.domain.image.dto.response.PresignedUrlResponse;
+import org.example.tablenow.domain.image.enums.ImageDomain;
+import org.example.tablenow.global.dto.AuthUser;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class ImageService {
+
+    private final S3Presigner presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.s3.presigned-url-expiration}")
+    private int expirationMinutes;
+
+    public PresignedUrlResponse generatePresignedUrl(AuthUser authUser, ImageDomain imageDomain, PresignedUrlRequest request) {
+        Long userId = authUser.getId();
+        String fileExtension = extractExtension(request.getFileName());
+        String uuid = UUID.randomUUID().toString();
+        String key = imageDomain.name().toLowerCase() + "/" + userId + "/" + uuid + fileExtension;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(request.getFileType().getMimeType())
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(
+                PutObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(expirationMinutes))
+                        .putObjectRequest(putObjectRequest)
+                        .build()
+        );
+
+        String uploadUrl = presignedRequest.url().toString();
+        String fileUrl = "https://" + bucketName + ".s3.amazonaws.com/" + key;
+
+        return PresignedUrlResponse.builder()
+                .uploadUrl(uploadUrl)
+                .fileUrl(fileUrl)
+                .build();
+    }
+
+    private String extractExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf('.')); // 예: ".png"
+    }
+}

--- a/src/main/java/org/example/tablenow/global/config/S3Config.java
+++ b/src/main/java/org/example/tablenow/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package org.example.tablenow.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private S3Presigner presigner;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -61,6 +61,10 @@ public enum ErrorCode {
     WAITLIST_FULL(HttpStatus.CONFLICT, "대기 정원이 꽉 찼습니다."),
     WAITLIST_NOT_FOUNND(HttpStatus.NOT_FOUND, "대기 정보가 존재하지 않습니다."),
 
+    // IMAGE
+    INVALID_IMAGE_DOMAIN(HttpStatus.BAD_REQUEST, "잘못된 이미지 도메인입니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
+
     // COMMON
     INVALID_SORT_FIELD(HttpStatus.BAD_REQUEST, "정렬 필드가 잘못되었습니다."),
     INVALID_ORDER_VALUE(HttpStatus.BAD_REQUEST, "정렬 옵션이 잘못되었습니다. 오름차순(asc) 또는 내림차순(desc)을 선택해주세요."),

--- a/src/main/java/org/example/tablenow/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/tablenow/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,6 +17,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse<String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        FieldError firstError = ex.getBindingResult().getFieldError();
+        String message = "유효성 검사에 실패했습니다.";
+
+        if (firstError != null) {
+            message = firstError.getDefaultMessage();
+        }
+
+        return new ResponseEntity<>(ErrorResponse.of(httpStatus, message), httpStatus);
+    }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse<String>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {

--- a/src/main/java/org/example/tablenow/global/util/RegexConstants.java
+++ b/src/main/java/org/example/tablenow/global/util/RegexConstants.java
@@ -8,6 +8,9 @@ public final class RegexConstants {
     // 10~11자리의 숫자 전화번호
     public static final String PHONE_NUMBER_REGEX = "^[0-9]{10,11}$";
 
+    // 파일 이름에 확장자가 포함되어 있는지 검증 (.확장자 형식)
+    public static final String IMAGE_FILE_NAME_REGEX = "^.+\\.(?i)(jpg|jpeg|png|webp)$";
+
     private RegexConstants() {
         // 인스턴스 생성 방지
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,14 @@ spring:
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}
+
+cloud:
+  aws:
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+      presigned-url-expiration: ${AWS_S3_PRESIGNED_EXPIRATION}


### PR DESCRIPTION
## 🔗 Issue Number
close #61 


## 📝 작업 내역
- [X] S3 의존성 추가
- [X] Presigned PUT Url 발급 API 구현


## 💡 PR 특이사항
- [spring-cloud-aws 버전 결정 참고](https://github.com/awspring/spring-cloud-aws/releases)
  - 내용 중: Spring Cloud AWS 3.3.0 brings compatibility with **Spring Boot 3.4**
- 업로드 대상 도메인(user/store)에 따라 S3 디렉토리 경로 분리
- 파일명은 저장 시 UUID + 확장자 형식으로 지정되며, Content-Type은 fileType 기준으로 설정

## 📸 스크린샷
- 이미지 업로드용 Presigned URL 및 업로드 성공 시 접근 가능한 다운로드 URL 반환
![image](https://github.com/user-attachments/assets/74c97d21-b29c-4ac4-a8ff-0c8633cbc0ce)

- Presigned URL을 사용하여 이미지 업로드
  - 성공
![image](https://github.com/user-attachments/assets/a334fdae-cfdd-4bc2-88e5-4d0e8a642bbf)
  - 실패(URL 시간 만료)
![image](https://github.com/user-attachments/assets/51b4c402-933b-4abb-b4d4-c181f306a9fe)

- S3
  - 로그인한 유저(id: 12)의 프로필 사진이 업로드 됨
![image](https://github.com/user-attachments/assets/d0542447-984c-4597-9911-ce99165eb8e0)

- 다운로드 URL 접근 확인
![image](https://github.com/user-attachments/assets/ed928946-ad27-4720-bc25-bb953b76d436)