### PR TITLE
[refactor] 가게 코드리뷰 피드백 반영

### DIFF
--- a/src/main/java/org/example/tablenow/domain/store/dto/request/StoreCreateRequestDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/request/StoreCreateRequestDto.java
@@ -3,6 +3,7 @@ package org.example.tablenow.domain.store.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tablenow.domain.image.annotation.ImageUrlPattern;
@@ -33,4 +34,17 @@ public class StoreCreateRequestDto {
     private Integer deposit;
     @NotNull(message = "카테고리는 필수값입니다.")
     private Long categoryId;
+
+    @Builder
+    public StoreCreateRequestDto(String name, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit, Long categoryId) {
+        this.name = name;
+        this.description = description;
+        this.address = address;
+        this.imageUrl = imageUrl;
+        this.capacity = capacity;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.deposit = deposit;
+        this.categoryId = categoryId;
+    }
 }

--- a/src/main/java/org/example/tablenow/domain/store/dto/request/StoreUpdateRequestDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/request/StoreUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package org.example.tablenow.domain.store.dto.request;
 
 import jakarta.validation.constraints.Min;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tablenow.domain.image.annotation.ImageUrlPattern;
@@ -25,4 +26,17 @@ public class StoreUpdateRequestDto {
     @Min(value = 0, message = "예약금은 0 미만일 수 없습니다.")
     private Integer deposit;
     private Long categoryId;
+
+    @Builder
+    public StoreUpdateRequestDto(String name, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit, Long categoryId) {
+        this.name = name;
+        this.description = description;
+        this.address = address;
+        this.imageUrl = imageUrl;
+        this.capacity = capacity;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.deposit = deposit;
+        this.categoryId = categoryId;
+    }
 }

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreDeleteResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreDeleteResponseDto.java
@@ -1,5 +1,6 @@
 package org.example.tablenow.domain.store.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -7,12 +8,16 @@ public class StoreDeleteResponseDto {
     private final Long storeId;
     private final String message;
 
+    @Builder
     public StoreDeleteResponseDto(Long storeId, String message) {
         this.storeId = storeId;
         this.message = message;
     }
 
     public static StoreDeleteResponseDto fromStore(Long storeId) {
-        return new StoreDeleteResponseDto(storeId, "삭제되었습니다.");
+        return StoreDeleteResponseDto.builder()
+                .storeId(storeId)
+                .message("삭제되었습니다.")
+                .build();
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/entity/Store.java
+++ b/src/main/java/org/example/tablenow/domain/store/entity/Store.java
@@ -39,7 +39,7 @@ public class Store extends TimeStamped {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private User user;
+    private User user; // UserRole: ROLE_OWNER
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
@@ -60,19 +60,43 @@ public class Store extends TimeStamped {
         this.category = category;
     }
 
-    public void update(String name, String description, String address, String imageUrl, int capacity, int deposit, LocalTime startTime, LocalTime endTime, Category category) {
+    public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateDescription(String description) {
         this.description = description;
+    }
+
+    public void updateAddress(String address) {
         this.address = address;
+    }
+
+    public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void updateCapacity(int capacity) {
         this.capacity = capacity;
+    }
+
+    public void updateDeposit(int deposit) {
         this.deposit = deposit;
+    }
+
+    public void updateStartTime(LocalTime startTime) {
         this.startTime = startTime;
+    }
+
+    public void updateEndTime(LocalTime endTime) {
         this.endTime = endTime;
+    }
+
+    public void updateCategory(Category category) {
         this.category = category;
     }
 
-    public void delete() {
+    public void deleteStore() {
         this.deletedAt = LocalDateTime.now();
     }
 
@@ -92,8 +116,7 @@ public class Store extends TimeStamped {
         return timeSlots;
     }
 
-    public boolean hasVacancy(long reservedCount){
+    public boolean hasVacancy(long reservedCount) {
         return reservedCount < this.capacity;
-
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/example/tablenow/domain/store/repository/StoreRepository.java
@@ -1,10 +1,12 @@
 package org.example.tablenow.domain.store.repository;
 
 import org.example.tablenow.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreQueryRepository {
+    @EntityGraph(attributePaths = {"category"}, type = EntityGraph.EntityGraphType.FETCH)
     Optional<Store> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/example/tablenow/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/StoreService.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StoreService {
 
     private final StoreRepository storeRepository;
@@ -49,12 +48,12 @@ public class StoreService {
     private static final Integer TARGET_DAY_LENGTH = 8;
 
     @Transactional
-    public StoreCreateResponseDto saveStore(AuthUser authUser, StoreCreateRequestDto requestDto) {
+    public StoreCreateResponseDto saveStore(AuthUser authUser, StoreCreateRequestDto request) {
         User user = User.fromAuthUser(authUser);
 
-        Category category = categoryService.findCategory(requestDto.getCategoryId());
+        Category category = categoryService.findCategory(request.getCategoryId());
 
-        validStoreTimes(requestDto.getStartTime(), requestDto.getEndTime());
+        validateStartTimeIsBeforeEndTime(request.getStartTime(), request.getEndTime());
 
         Long count = storeRepository.countActiveStoresByUser(user.getId());
         if (count >= MAX_STORES_COUNT) {
@@ -62,14 +61,14 @@ public class StoreService {
         }
 
         Store store = Store.builder()
-                .name(requestDto.getName())
-                .description(requestDto.getDescription())
-                .address(requestDto.getAddress())
-                .imageUrl(requestDto.getImageUrl())
-                .capacity(requestDto.getCapacity())
-                .deposit(requestDto.getDeposit())
-                .startTime(requestDto.getStartTime())
-                .endTime(requestDto.getEndTime())
+                .name(request.getName())
+                .description(request.getDescription())
+                .address(request.getAddress())
+                .imageUrl(request.getImageUrl())
+                .capacity(request.getCapacity())
+                .deposit(request.getDeposit())
+                .startTime(request.getStartTime())
+                .endTime(request.getEndTime())
                 .user(user)
                 .category(category)
                 .build();
@@ -78,46 +77,62 @@ public class StoreService {
         return StoreCreateResponseDto.fromStore(savedStore);
     }
 
+    @Transactional(readOnly = true)
     public List<StoreResponseDto> findMyStores(AuthUser authUser) {
         User user = User.fromAuthUser(authUser);
         return storeRepository.findAllByUserId(user.getId());
     }
 
     @Transactional
-    public StoreUpdateResponseDto updateStore(Long id, AuthUser authUser, StoreUpdateRequestDto requestDto) {
+    public StoreUpdateResponseDto updateStore(Long id, AuthUser authUser, StoreUpdateRequestDto request) {
         User user = User.fromAuthUser(authUser);
-
         Store store = getStore(id);
-
         validStoreOwnerId(store, user);
+        validateUpdateStoreTime(request, store);
 
-        Category category = store.getCategory();
-        if (requestDto.getCategoryId() != null) {
-            category = categoryService.findCategory(requestDto.getCategoryId());
+        if (request.getCategoryId() != null) {
+            Category category = categoryService.findCategory(request.getCategoryId());
+            store.updateCategory(category);
         }
 
-        // 업데이트 필드 구분
-        LocalTime startTime = Objects.isNull(requestDto.getStartTime()) ? store.getStartTime() : requestDto.getStartTime();
-        LocalTime endTime = Objects.isNull(requestDto.getEndTime()) ? store.getEndTime() : requestDto.getEndTime();
-        validStoreTimes(startTime, endTime);
-
-        String name = StringUtils.hasText(requestDto.getName()) ? requestDto.getName() : store.getName();
-        String description = StringUtils.hasText(requestDto.getDescription()) ? requestDto.getDescription() : store.getDescription();
-        String address = StringUtils.hasText(requestDto.getAddress()) ? requestDto.getAddress() : store.getAddress();
-
-        String storeImageUrl = Optional.ofNullable(store.getImageUrl()).orElse(null);
-        String requestImageUrl = Optional.ofNullable(requestDto.getImageUrl()).orElse(null);
-
-        String imageUrl = Objects.equals(storeImageUrl, requestImageUrl) ? storeImageUrl : requestImageUrl;
-
-        if (!Objects.equals(imageUrl, storeImageUrl) && StringUtils.hasText(storeImageUrl)) {
-            imageService.delete(storeImageUrl);
+        if (request.getStartTime() != null) {
+            store.updateStartTime(request.getStartTime());
         }
 
-        int capacity = Objects.isNull(requestDto.getCapacity()) ? store.getCapacity() : requestDto.getCapacity();
-        int deposit = Objects.isNull(requestDto.getDeposit()) ? store.getDeposit() : requestDto.getDeposit();
+        if (request.getEndTime() != null) {
+            store.updateEndTime(request.getEndTime());
+        }
 
-        store.update(name, description, address, imageUrl, capacity, deposit, startTime, endTime, category);
+        if (StringUtils.hasText(request.getName())) {
+            store.updateName(request.getName());
+        }
+
+        if (StringUtils.hasText(request.getDescription())) {
+            store.updateDescription(request.getDescription());
+        }
+
+        if (StringUtils.hasText(request.getAddress())) {
+            store.updateAddress(request.getAddress());
+        }
+
+        String storeImageUrl = store.getImageUrl();
+        String requestImageUrl = request.getImageUrl();
+
+        if (StringUtils.hasText(requestImageUrl)) {
+            if (!requestImageUrl.equals(storeImageUrl) && StringUtils.hasText(storeImageUrl)) {
+                imageService.delete(storeImageUrl);
+            }
+            store.updateImageUrl(requestImageUrl);
+        }
+
+        if (request.getCapacity() != null) {
+            store.updateCapacity(request.getCapacity());
+        }
+
+        if (request.getDeposit() != null) {
+            store.updateDeposit(request.getDeposit());
+        }
+
         return StoreUpdateResponseDto.fromStore(store);
     }
 
@@ -129,15 +144,15 @@ public class StoreService {
 
         validStoreOwnerId(store, user);
 
-        // 가게 이미지 리소스 확인
         if (StringUtils.hasText(store.getImageUrl())) {
             imageService.delete(store.getImageUrl());
         }
 
-        store.delete();
+        store.deleteStore();
         return StoreDeleteResponseDto.fromStore(store.getId());
     }
 
+    @Transactional(readOnly = true)
     public Page<StoreSearchResponseDto> findAllStores(AuthUser authUser, int page, int size, String sort, String direction, Long categoryId, String search) {
         try {
             Sort sortOption = Sort.by(Sort.Direction.fromString(direction), StoreSortField.fromString(sort));
@@ -167,27 +182,21 @@ public class StoreService {
         }
     }
 
+    @Transactional(readOnly = true)
     public StoreResponseDto findStore(Long id) {
         return StoreResponseDto.fromStore(getStore(id));
     }
 
+    @Transactional(readOnly = true)
     public List<StoreRankingResponseDto> getStoreRanking(int limit, String timeKey) {
-        List<StoreRankingResponseDto> result = new ArrayList<>();
-
         Map<String, Integer> rankMap;
 
-        String target = StringUtils.hasText(timeKey) ? timeKey : LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+        String target = validateTimeKey(timeKey);
 
-        if (TARGET_HOUR_LENGTH == target.length()) {
-            rankMap = getKeywordRankingByHour(target);
-        } else if (TARGET_DAY_LENGTH == target.length()) {
-            rankMap = getKeywordRankingByDay(target);
-        } else {
-            throw new HandledException(ErrorCode.STORE_RANKING_TIME_KEY_ERROR);
-        }
+        rankMap = getRankMapByTimeKey(target);
 
         if (rankMap.isEmpty()) {
-            return result;
+            return Collections.emptyList();
         }
 
         AtomicInteger rank = new AtomicInteger(1);
@@ -202,6 +211,44 @@ public class StoreService {
                 .toList();
     }
 
+    public Store getStore(Long id) {
+        return storeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new HandledException(ErrorCode.STORE_NOT_FOUND));
+    }
+
+    public void validStoreOwnerId(Store store, User user) {
+        // 요청한 유저 ID가 가게 주인인지 확인
+        if (!store.getUser().getId().equals(user.getId())) {
+            throw new HandledException(ErrorCode.STORE_FORBIDDEN);
+        }
+    }
+
+    private void validateUpdateStoreTime(StoreUpdateRequestDto request, Store store) {
+        LocalTime startTime = request.getStartTime() != null ? request.getStartTime() : store.getStartTime();
+        LocalTime endTime = request.getEndTime() != null ? request.getEndTime() : store.getEndTime();
+        validateStartTimeIsBeforeEndTime(startTime, endTime);
+    }
+
+    private void validateStartTimeIsBeforeEndTime(LocalTime startTime, LocalTime endTime) {
+        if (!startTime.isBefore(endTime)) {
+            throw new HandledException(ErrorCode.STORE_BAD_REQUEST_TIME);
+        }
+    }
+
+    private String validateTimeKey(String timeKey) {
+        return StringUtils.hasText(timeKey) ? timeKey : LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+
+    private Map<String, Integer> getRankMapByTimeKey(String timeKey) {
+        if (TARGET_HOUR_LENGTH == timeKey.length()) {
+            return getKeywordRankingByHour(timeKey);
+        } else if (TARGET_DAY_LENGTH == timeKey.length()) {
+            return getKeywordRankingByDay(timeKey);
+        } else {
+            throw new HandledException(ErrorCode.STORE_RANKING_TIME_KEY_ERROR);
+        }
+    }
+
     private Map<String, Integer> getKeywordRankingByHour(String timeKey) {
         Map<String, Integer> rankMap = new LinkedHashMap<>();
 
@@ -209,7 +256,7 @@ public class StoreService {
         Set<ZSetOperations.TypedTuple<String>> tuples = redisTemplate.opsForZSet()
                 .reverseRangeWithScores(rankKey, 0L, -1);
 
-        if (tuples == null || tuples.isEmpty()) {
+        if (tuples.isEmpty()) {
             return rankMap;
         }
 
@@ -230,7 +277,7 @@ public class StoreService {
             Set<ZSetOperations.TypedTuple<String>> tuples =
                     redisTemplate.opsForZSet().reverseRangeWithScores(rankKey, 0, -1);
 
-            if (tuples == null) {
+            if (tuples.isEmpty()) {
                 continue;
             }
 
@@ -241,23 +288,5 @@ public class StoreService {
             }
         }
         return result;
-    }
-
-    public Store getStore(Long id) {
-        return storeRepository.findByIdAndDeletedAtIsNull(id)
-                .orElseThrow(() -> new HandledException(ErrorCode.STORE_NOT_FOUND));
-    }
-
-    public void validStoreOwnerId(Store store, User user) {
-        // 요청한 유저 ID가 가게 주인인지 확인
-        if (!store.getUser().getId().equals(user.getId())) {
-            throw new HandledException(ErrorCode.STORE_FORBIDDEN);
-        }
-    }
-
-    private void validStoreTimes(LocalTime startTime, LocalTime endTime) {
-        if (!startTime.isBefore(endTime)) {
-            throw new HandledException(ErrorCode.STORE_BAD_REQUEST_TIME);
-        }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/StoreService.java
@@ -46,6 +46,7 @@ public class StoreService {
     private static final Long MAX_STORES_COUNT = 3L;
     private static final Integer TARGET_HOUR_LENGTH = 10;
     private static final Integer TARGET_DAY_LENGTH = 8;
+    private static final DateTimeFormatter TIME_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
 
     @Transactional
     public StoreCreateResponseDto saveStore(AuthUser authUser, StoreCreateRequestDto request) {
@@ -117,9 +118,8 @@ public class StoreService {
 
         String storeImageUrl = store.getImageUrl();
         String requestImageUrl = request.getImageUrl();
-
         if (StringUtils.hasText(requestImageUrl)) {
-            if (!requestImageUrl.equals(storeImageUrl) && StringUtils.hasText(storeImageUrl)) {
+            if (!Objects.equals(requestImageUrl, storeImageUrl) && StringUtils.hasText(storeImageUrl)) {
                 imageService.delete(storeImageUrl);
             }
             store.updateImageUrl(requestImageUrl);
@@ -169,7 +169,7 @@ public class StoreService {
                     redisTemplate.opsForValue().set(userKey, "1", 12, TimeUnit.HOURS);
 
                     // 시간 단위 랭킹 키 생성
-                    String hourKey = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+                    String hourKey = LocalDateTime.now().format(TIME_KEY_FORMATTER);
                     String rankKey = StoreRedisKey.STORE_KEYWORD_RANK_KEY + ":" + hourKey;
 
                     // 키워드 랭킹 score 증가
@@ -236,7 +236,7 @@ public class StoreService {
     }
 
     private String validateTimeKey(String timeKey) {
-        return StringUtils.hasText(timeKey) ? timeKey : LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+        return StringUtils.hasText(timeKey) ? timeKey : LocalDateTime.now().format(TIME_KEY_FORMATTER);
     }
 
     private Map<String, Integer> getRankMapByTimeKey(String timeKey) {

--- a/src/test/java/org/example/tablenow/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/store/service/StoreServiceTest.java
@@ -2,6 +2,7 @@ package org.example.tablenow.domain.store.service;
 
 import org.example.tablenow.domain.category.entity.Category;
 import org.example.tablenow.domain.category.service.CategoryService;
+import org.example.tablenow.domain.image.service.ImageService;
 import org.example.tablenow.domain.store.dto.request.StoreCreateRequestDto;
 import org.example.tablenow.domain.store.dto.request.StoreUpdateRequestDto;
 import org.example.tablenow.domain.store.dto.response.*;
@@ -13,7 +14,6 @@ import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +45,8 @@ public class StoreServiceTest {
     private StoreRepository storeRepository;
     @Mock
     private CategoryService categoryService;
+    @Mock
+    private ImageService imageService;
     @Mock
     private RedisTemplate<String, String> redisTemplate;
     @Mock
@@ -82,21 +84,16 @@ public class StoreServiceTest {
 
     @Nested
     class 가게_등록 {
-        StoreCreateRequestDto dto = new StoreCreateRequestDto();
-
-        @BeforeEach
-        void setUp() {
-            ReflectionTestUtils.setField(dto, "name", "맛있는 가게");
-            ReflectionTestUtils.setField(dto, "description", "가게 설명입니다.");
-            ReflectionTestUtils.setField(dto, "address", "서울특별시 강남구 테헤란로11길 1 1층");
-            ReflectionTestUtils.setField(dto, "imageUrl", "대표이미지");
-            ReflectionTestUtils.setField(dto, "capacity", 100);
-            ReflectionTestUtils.setField(dto, "startTime", LocalTime.of(9, 00));
-            ReflectionTestUtils.setField(dto, "endTime", LocalTime.of(21, 00));
-            ReflectionTestUtils.setField(dto, "deposit", 10000);
-            ReflectionTestUtils.setField(dto, "categoryId", categoryId);
-        }
-
+        StoreCreateRequestDto dto = StoreCreateRequestDto.builder()
+                .name("맛있는 가게")
+                .description("가게 설명입니다.")
+                .address("서울특별시 강남구 테헤란로11길 1 1층")
+                .capacity(100)
+                .startTime(LocalTime.of(9, 00))
+                .endTime(LocalTime.of(21, 00))
+                .deposit(10000)
+                .categoryId(categoryId)
+                .build();
 
         @Test
         void 존재하지_않는_카테고리_조회_시_예외_발생() {
@@ -196,20 +193,16 @@ public class StoreServiceTest {
     class 가게_수정 {
         Long categoryId2 = 2L;
         Category category2 = Category.builder().id(categoryId2).name("분식").build();
-        StoreUpdateRequestDto dto = new StoreUpdateRequestDto();
-
-        @BeforeEach
-        void setUp() {
-            ReflectionTestUtils.setField(dto, "name", "더 맛있는 가게");
-            ReflectionTestUtils.setField(dto, "description", "더 맛있는 가게 설명입니다.");
-            ReflectionTestUtils.setField(dto, "address", "서울특별시 강남구 테헤란로22길 2 2층");
-            ReflectionTestUtils.setField(dto, "imageUrl", "수정이미지");
-            ReflectionTestUtils.setField(dto, "capacity", 200);
-            ReflectionTestUtils.setField(dto, "startTime", LocalTime.of(8, 00));
-            ReflectionTestUtils.setField(dto, "endTime", LocalTime.of(22, 00));
-            ReflectionTestUtils.setField(dto, "deposit", 20000);
-            ReflectionTestUtils.setField(dto, "categoryId", categoryId2);
-        }
+        StoreUpdateRequestDto dto = StoreUpdateRequestDto.builder()
+                .name("더 맛있는 가게")
+                .description("더 맛있는 가게 설명입니다.")
+                .address("서울특별시 강남구 테헤란로22길 2 2층")
+                .capacity(200)
+                .startTime(LocalTime.of(8, 00))
+                .endTime(LocalTime.of(22, 00))
+                .deposit(20000)
+                .categoryId(categoryId2)
+                .build();
 
         @Test
         void 존재하지_않는_가게_조회_시_예외_발생() {
@@ -283,6 +276,61 @@ public class StoreServiceTest {
             );
         }
 
+        @Nested
+        class 가게_이미지_수정 {
+            String origin = "https://url.com/store/1/origin.jpg";
+            String request = "https://url.com/store/1/update.jpg";
+
+            @Test
+            void 기존_이미지가_존재하지_않는_경우_수정_성공() {
+                // given
+                ReflectionTestUtils.setField(dto, "imageUrl", request);
+                given(storeRepository.findByIdAndDeletedAtIsNull(anyLong())).willReturn(Optional.of(store));
+                given(categoryService.findCategory(anyLong())).willReturn(category2);
+
+                // when
+                StoreUpdateResponseDto response = storeService.updateStore(storeId, authOwner, dto);
+
+                // then
+                assertNotNull(response);
+                assertEquals(response.getImageUrl(), dto.getImageUrl());
+            }
+
+            @Test
+            void 기존_이미지가_존재할_경우_이미지_삭제_및_수정_성공() {
+                // given
+                ReflectionTestUtils.setField(store, "imageUrl", origin);
+                ReflectionTestUtils.setField(dto, "imageUrl", request);
+                given(storeRepository.findByIdAndDeletedAtIsNull(anyLong())).willReturn(Optional.of(store));
+                given(categoryService.findCategory(anyLong())).willReturn(category2);
+
+                // when
+                StoreUpdateResponseDto response = storeService.updateStore(storeId, authOwner, dto);
+
+                // then
+                assertNotNull(response);
+                assertEquals(response.getImageUrl(), dto.getImageUrl());
+
+            }
+
+            @Test
+            void 기존_이미지와_동일한_이미지_URL_요청_시_수정_성공() {
+                // given
+                ReflectionTestUtils.setField(store, "imageUrl", origin);
+                ReflectionTestUtils.setField(dto, "imageUrl", origin);
+                given(storeRepository.findByIdAndDeletedAtIsNull(anyLong())).willReturn(Optional.of(store));
+                given(categoryService.findCategory(anyLong())).willReturn(category2);
+
+                // when
+                StoreUpdateResponseDto response = storeService.updateStore(storeId, authOwner, dto);
+
+                // then
+                assertNotNull(response);
+                assertEquals(response.getImageUrl(), dto.getImageUrl());
+
+            }
+        }
+
         @Test
         void 수정_성공() {
             // given
@@ -329,6 +377,20 @@ public class StoreServiceTest {
                     storeService.deleteStore(storeId, authOwner)
             );
             assertEquals(exception.getMessage(), ErrorCode.STORE_FORBIDDEN.getDefaultMessage());
+        }
+
+        @Test
+        void 이미지_삭제_처리_후_삭제_성공() {
+            // given
+            ReflectionTestUtils.setField(store, "imageUrl", "https://url.com/store/1/origin.jpg");
+            given(storeRepository.findByIdAndDeletedAtIsNull(anyLong())).willReturn(Optional.of(store));
+
+            // when
+            StoreDeleteResponseDto response = storeService.deleteStore(storeId, authOwner);
+
+            // then
+            assertNotNull(response);
+            assertEquals(response.getStoreId(), storeId);
         }
 
         @Test
@@ -494,23 +556,7 @@ public class StoreServiceTest {
         }
 
         @Test
-        void 캐시_키_초기화_후_조회_성공() {
-            // given
-            String rankKey = StoreRedisKey.STORE_KEYWORD_RANK_KEY + ":" + timeKey;
-            given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
-            given(zSetOperations.reverseRangeWithScores(rankKey, 0L, -1))
-                    .willReturn(null);
-
-            // when
-            List<StoreRankingResponseDto> response = storeService.getStoreRanking(limit, timeKey);
-
-            // then
-            assertNotNull(response);
-            assertEquals(response.size(), 0);
-        }
-
-        @Test
-        void 캐시_빈_내부_데이터_조회_성공() {
+        void 인기_검색어_캐시가_없을_경우_빈_배열_조회_성공() {
             // given
             String rankKey = StoreRedisKey.STORE_KEYWORD_RANK_KEY + ":" + timeKey;
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
@@ -526,15 +572,15 @@ public class StoreServiceTest {
         }
 
         @Test
-        void 시간_집계_키를_입력하지_않은_경우_현재_시간_기준_조회_성공() {
+        void 시간_집계_키가_없을_경우_현재_시간_기준_조회_성공() {
             // given
             String rankKey = StoreRedisKey.STORE_KEYWORD_RANK_KEY + ":" + timeKey;
             given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
             given(zSetOperations.reverseRangeWithScores(rankKey, 0L, -1))
-                    .willReturn(null);
+                    .willReturn(Collections.emptySet());
 
             // when
-            List<StoreRankingResponseDto> response = storeService.getStoreRanking(limit, "");
+            List<StoreRankingResponseDto> response = storeService.getStoreRanking(limit, null);
 
             // then
             assertNotNull(response);
@@ -570,7 +616,7 @@ public class StoreServiceTest {
             given(zSetOperations.reverseRangeWithScores(anyString(), anyLong(), anyLong()))
                     .willReturn(mockResult);
             given(zSetOperations.reverseRangeWithScores(rankKey, 0L, -1))
-                    .willReturn(null);
+                    .willReturn(Collections.emptySet());
 
             // when
             List<StoreRankingResponseDto> response = storeService.getStoreRanking(limit, dayKey);


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #68
close #73

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
> #68 테스트파일 리팩토링 
가게 수정, 삭제 시 기존 이미지가 있는 경우 해당 이미지 리소스 찾아서 삭제

> #73 가게 코드리뷰 피드백 반영
`가게 수정`: 가독성 측면을 고려하여 필드 업데이트 메서드 분리
`인기 검색어 조회`: timeKey 검증, 시간별-일자별 구분 분기처리 메서드 추출

- [X] storeService 빈 리스트 반환
- [X] 인기 검색어 조회 timeKey 관련 메서드 extract
- [X] Store 필드명 주석 설명
- [X] Entity, Dto 생성자, 빌더 정리
- [X] 테스트코드 리팩토링


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
* 유효성 검사 관련 메서드명을 valid~로 작성했으나 프로젝트 전체 코드 포맷 일관성을 위해 validate로 변경할 예정입니다.
* 이에 따라 storeService의 validStoreOwnerId를 호출하는 예약(reservation) 의 코드가 일부 변경될 예정입니다. (예상: reservationService 및 테스트코드)


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
* 가게 이미지 변경 테스트
![스크린샷 2025-04-11 오후 3 54 44](https://github.com/user-attachments/assets/79b1bfa2-e526-493e-9d4a-882882b973c2)

![image](https://github.com/user-attachments/assets/8bb0daf2-de7e-41ba-a418-9203c6b06cee)
