### PR TITLE
[refactor] 카테고리 피드백 반영

### DIFF
--- a/src/main/java/org/example/tablenow/domain/category/dto/response/CategoryDeleteResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/category/dto/response/CategoryDeleteResponseDto.java
@@ -1,18 +1,23 @@
 package org.example.tablenow.domain.category.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class CategoryDeleteResponseDto {
-    private final Long id;
+    private final Long categoryId;
     private final String message;
 
-    public CategoryDeleteResponseDto(Long id, String message) {
-        this.id = id;
+    @Builder
+    public CategoryDeleteResponseDto(Long categoryId, String message) {
+        this.categoryId = categoryId;
         this.message = message;
     }
 
     public static CategoryDeleteResponseDto fromCategory(Long id) {
-        return new CategoryDeleteResponseDto(id, "삭제되었습니다.");
+        return CategoryDeleteResponseDto.builder()
+                .categoryId(id)
+                .message("삭제되었습니다.")
+                .build();
     }
 }

--- a/src/main/java/org/example/tablenow/domain/category/dto/response/CategoryResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/category/dto/response/CategoryResponseDto.java
@@ -1,5 +1,6 @@
 package org.example.tablenow.domain.category.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import org.example.tablenow.domain.category.entity.Category;
 
@@ -8,12 +9,16 @@ public class CategoryResponseDto {
     private final Long categoryId;
     private final String name;
 
+    @Builder
     public CategoryResponseDto(Long categoryId, String name) {
         this.categoryId = categoryId;
         this.name = name;
     }
 
     public static CategoryResponseDto fromCategory(Category category) {
-        return new CategoryResponseDto(category.getId(), category.getName());
+        return CategoryResponseDto.builder()
+                .categoryId(category.getId())
+                .name(category.getName())
+                .build();
     }
 }

--- a/src/main/java/org/example/tablenow/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/tablenow/domain/category/service/CategoryService.java
@@ -24,9 +24,7 @@ public class CategoryService {
 
     @Transactional
     public CategoryResponseDto saveCategory(CategoryRequestDto requestDto) {
-        findCategoryByName(requestDto.getName()).ifPresent(it -> {
-            throw new HandledException(ErrorCode.CATEGORY_ALREADY_EXISTS);
-        });
+        validateExistCategory(requestDto);
         Category category = Category.builder().name(requestDto.getName()).build();
         Category savedCategory = categoryRepository.save(category);
         return CategoryResponseDto.fromCategory(savedCategory);
@@ -35,9 +33,7 @@ public class CategoryService {
     @Transactional
     public CategoryResponseDto updateCategory(Long id, CategoryRequestDto requestDto) {
         Category category = findCategory(id);
-        findCategoryByName(requestDto.getName()).ifPresent(it -> {
-            throw new HandledException(ErrorCode.CATEGORY_ALREADY_EXISTS);
-        });
+        validateExistCategory(requestDto);
         category.updateName(requestDto.getName());
         return CategoryResponseDto.fromCategory(category);
     }
@@ -62,5 +58,11 @@ public class CategoryService {
 
     public Optional<Category> findCategoryByName(String name) {
         return categoryRepository.findByName(name);
+    }
+
+    private void validateExistCategory(CategoryRequestDto requestDto) {
+        findCategoryByName(requestDto.getName()).ifPresent(it -> {
+            throw new HandledException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        });
     }
 }

--- a/src/test/java/org/example/tablenow/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/category/service/CategoryServiceTest.java
@@ -143,7 +143,7 @@ public class CategoryServiceTest {
 
             // then
             assertNotNull(response);
-            assertEquals(response.getId(), categoryId);
+            assertEquals(response.getCategoryId(), categoryId);
         }
     }
 


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #81

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
Entity, Dto의 생성자, 빌더, 접근제한자가 적절하게 적용되었는지 검토
카테고리 중복체크 메서드 추출 -> validExistCategory

- [X] Category, CategoryRequestDto, CategoryResponseDto 검토
- [X] CategoryService: 카테고리 중복체크 메서드

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- 피드백: ifPresent() → orElse()
> 해당 로직은 동일한 카테고리명의 중복 등록을 방지하기 위해 DB 조회 시 동일한 카테고리명이 있을 경우 예외처리를 위해 작성되어 ifPresent()로 작성하였습니다.

따라서 orElse로 변경하지는 않았으나 등록 API, 수정 API 에서 해당 예외처리가 필요하여 메서드 추출로 중복코드를 삭제하였습니다.

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
* orElse 수정 시 서버 에러 발생
![image](https://github.com/user-attachments/assets/ba6e5d3f-9a82-4d5c-af68-63cb8b17d88e)

* 중복 유효성 검사 실패
![스크린샷 2025-04-11 오후 5 52 48](https://github.com/user-attachments/assets/e4562a43-f74a-4246-a081-6cfa4f70a75a)
