### PR TITLE
[test] AuthServiceTest 통합 테스트 개선

### DIFF
--- a/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
@@ -2,26 +2,29 @@ package org.example.tablenow.domain.auth.service;
 
 import org.example.tablenow.domain.auth.dto.request.SigninRequest;
 import org.example.tablenow.domain.auth.dto.request.SignupRequest;
+import org.example.tablenow.domain.auth.dto.response.SignupResponse;
 import org.example.tablenow.domain.auth.dto.response.TokenResponse;
 import org.example.tablenow.domain.auth.repository.RefreshTokenRepository;
-import org.example.tablenow.domain.auth.dto.response.SignupResponse;
+import org.example.tablenow.domain.user.dto.request.UserDeleteRequest;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.domain.user.repository.UserRepository;
+import org.example.tablenow.domain.user.service.UserService;
+import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class AuthServiceTest {
@@ -40,6 +43,9 @@ class AuthServiceTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Autowired
+    private UserService userService;
+
     @Nested
     class 회원가입 {
         SignupRequest request = SignupRequest.builder()
@@ -50,8 +56,6 @@ class AuthServiceTest {
                 .phoneNumber("01012345678")
                 .userRole(UserRole.ROLE_USER)
                 .build();
-
-        // Exception Start
 
         @Test
         void 중복된_이메일로_가입_시_예외() {
@@ -64,22 +68,21 @@ class AuthServiceTest {
                     .hasMessage(ErrorCode.DUPLICATE_EMAIL.getDefaultMessage());
         }
 
-        // Exception End
-
         @Test
-        void 성공() {
+        void 회원가입_성공() {
             // given
             SignupResponse signupResponse = authService.signup(request);
 
             // when
-            User findUser = userRepository.findById(signupResponse.getId())
-                    .orElseThrow(() -> new HandledException(ErrorCode.USER_NOT_FOUND));
+            User findUser = userService.getUser(signupResponse.getId());
 
             // then
-            assertThat(findUser)
-                    .extracting("email", "name", "nickname", "phoneNumber", "userRole")
-                    .containsExactly(request.getEmail(), request.getName(), request.getNickname(), request.getPhoneNumber(), request.getUserRole());
-            assertThat(passwordEncoder.matches(request.getPassword(), findUser.getPassword())).isTrue();
+            assertAll(
+                    () -> assertThat(findUser)
+                            .extracting("email", "name", "nickname", "phoneNumber", "userRole")
+                            .containsExactly(request.getEmail(), request.getName(), request.getNickname(), request.getPhoneNumber(), request.getUserRole()),
+                    () -> assertThat(passwordEncoder.matches(request.getPassword(), findUser.getPassword())).isTrue()
+            );
         }
     }
 
@@ -99,8 +102,6 @@ class AuthServiceTest {
                 .userRole(UserRole.ROLE_USER)
                 .build();
 
-        // Exception Start
-
         @Test
         void 해당_이메일의_사용자가_존재하지_않을_시_예외() {
             // when & then
@@ -109,19 +110,23 @@ class AuthServiceTest {
                     .hasMessage(ErrorCode.USER_NOT_FOUND.getDefaultMessage());
         }
 
-//        @Test
-//        void 탈퇴한_사용자가_로그인_시도_시_예외() {
-//            // given
-//            UserResponse userResponse = authService.signup(signupRequest);
-//            User findUser = userRepository.findById(userResponse.getId())
-//                    .orElseThrow(() -> new HandledException(ErrorCode.USER_NOT_FOUND));
-//            // TODO: 회원(findUser) 탈퇴 API 실행
-//
-//            // when & then
-//            assertThatThrownBy(() -> authService.signin(request))
-//                    .isInstanceOf(HandledException.class)
-//                    .hasMessage(ErrorCode.ALREADY_DELETED_USER.getDefaultMessage());
-//        }
+        @Test
+        void 탈퇴한_사용자가_로그인_시도_시_예외() {
+            // given
+            SignupResponse signupResponse = authService.signup(signupRequest);
+            User findUser = userService.getUser(signupResponse.getId());
+
+            AuthUser authUser = new AuthUser(findUser.getId(), findUser.getEmail(), findUser.getUserRole(), findUser.getNickname());
+            UserDeleteRequest deleteRequest = UserDeleteRequest.builder()
+                    .password(request.getPassword())
+                    .build();
+            userService.deleteUser(authUser, deleteRequest);
+
+            // when & then
+            assertThatThrownBy(() -> authService.signin(request))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.ALREADY_DELETED_USER.getDefaultMessage());
+        }
 
         @Test
         void 비밀번호가_저장된_비밀번호와_일치하지_않을_시_예외() {
@@ -138,10 +143,8 @@ class AuthServiceTest {
                     .hasMessage(ErrorCode.INCORRECT_PASSWORD.getDefaultMessage());
         }
 
-        // Exception End
-
         @Test
-        void 성공() {
+        void 로그인_성공() {
             // given
             authService.signup(signupRequest);
 
@@ -149,28 +152,35 @@ class AuthServiceTest {
             TokenResponse tokenResponse = authService.signin(request);
 
             // then
-            assertThat(tokenResponse.getAccessToken())
-                    .isNotNull()
-                    .contains("Bearer");
-            assertThat(tokenResponse.getRefreshToken())
-                    .isNotNull();
+            assertAll(
+                    () -> assertThat(tokenResponse.getAccessToken())
+                            .isNotNull()
+                            .contains("Bearer"),
+                    () -> assertThat(tokenResponse.getRefreshToken())
+                            .isNotNull()
+            );
         }
     }
 
     @Nested
     class 토큰_재발급 {
-        User user = User.builder()
-                .email("refresh@test.com")
-                .name("이름")
-                .nickname("닉네임")
-                .phoneNumber("01012345678")
-                .userRole(UserRole.ROLE_USER)
-                .build();
-        User savedUser = userRepository.save(user);
-        String oldRefreshToken = tokenService.createRefreshToken(savedUser);
-        String oldAccessToken = tokenService.createAccessToken(savedUser);
+        User savedUser;
+        String oldRefreshToken;
+        String oldAccessToken;
 
-        // Exception Start
+        @BeforeEach
+        void setup() {
+            User user = User.builder()
+                    .email("refresh@test.com")
+                    .name("이름")
+                    .nickname("닉네임")
+                    .phoneNumber("01012345678")
+                    .userRole(UserRole.ROLE_USER)
+                    .build();
+            savedUser = userRepository.save(user);
+            oldRefreshToken = tokenService.createRefreshToken(savedUser);
+            oldAccessToken = tokenService.createAccessToken(savedUser);
+        }
 
         @Test
         void 리프레시_토큰에_저장된_유저가_존재하지_않을_시_예외() {
@@ -183,32 +193,36 @@ class AuthServiceTest {
                     .hasMessage(ErrorCode.USER_NOT_FOUND.getDefaultMessage());
         }
 
-        // Exception End
-
         @Test
-        void 성공() {
+        void 토큰_재발급_성공() {
             // when
             TokenResponse tokenResponse = authService.refreshToken(oldRefreshToken);
             String newAccessToken = tokenResponse.getAccessToken();
             String newRefreshToken = tokenResponse.getRefreshToken();
 
             // then
-            assertThat(newAccessToken).isNotNull();
-            assertThat(newRefreshToken).isNotNull();
-            assertThat(newAccessToken).isNotEqualTo(oldAccessToken);
-            assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
+            assertAll(
+                    () -> assertThat(newAccessToken).isNotNull(),
+                    () -> assertThat(newRefreshToken).isNotNull(),
+                    () -> assertThat(newAccessToken).isNotEqualTo(oldAccessToken),
+                    () -> assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken)
+            );
         }
     }
 
     @Nested
     class 로그아웃 {
-        User user = User.builder()
-                .id(-1L)
-                .build();
+        User user = userRepository.save(User.builder()
+                .email("logout@test.com")
+                .name("이름")
+                .nickname("닉네임")
+                .phoneNumber("01012345678")
+                .userRole(UserRole.ROLE_USER)
+                .build());
         String refreshToken = tokenService.createRefreshToken(user);
 
         @Test
-        void 성공() {
+        void 로그아웃_성공() {
             // when
             authService.logout(refreshToken);
 

--- a/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
@@ -12,13 +12,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class TokenServiceTest {


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #99 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] UserService 활용하여 회원 탈퇴 테스트 추가
- [X] 토큰 재발급 테스트에서 BeforeEach로 테스트 간 상태 분리
- [X] 로그아웃 테스트에서 실제 유저 저장 후 토큰 발급으로 변경

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- `@ActiveProfiles("test")` 제거

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/9c51bcd2-98e7-4410-a064-e2674072d96f)