### PR TITLE
[test] 평점 API 테스트코드 작성

### DIFF
--- a/src/main/java/org/example/tablenow/domain/rating/repository/RatingRepository.java
+++ b/src/main/java/org/example/tablenow/domain/rating/repository/RatingRepository.java
@@ -19,6 +19,5 @@ public interface RatingRepository extends CrudRepository<Rating, Long> {
             """)
     boolean existsByUserAndStore(Long userId, Long storeId);
 
-    @EntityGraph(attributePaths = {"user", "store"}, type = EntityGraph.EntityGraphType.FETCH)
-    Optional<Rating> findByUserAndStore(User user, Store store);
+    Optional<Rating> findByUserIdAndStoreId(Long userId, Long storeId);
 }

--- a/src/main/java/org/example/tablenow/domain/rating/service/RatingService.java
+++ b/src/main/java/org/example/tablenow/domain/rating/service/RatingService.java
@@ -50,7 +50,7 @@ public class RatingService {
     public RatingUpdateResponseDto updateRating(AuthUser authUser, Long storeId, RatingRequestDto requestDto) {
         User user = User.fromAuthUser(authUser);
         Store store = storeService.getStore(storeId);
-        Rating rating = getRating(user, store);
+        Rating rating = getRating(user.getId(), store.getId());
 
         int oldRating = rating.getRating();
         int newRating = requestDto.getRating();
@@ -65,7 +65,7 @@ public class RatingService {
     public RatingDeleteResponseDto deleteRating(AuthUser authUser, Long storeId) {
         User user = User.fromAuthUser(authUser);
         Store store = storeService.getStore(storeId);
-        Rating rating = getRating(user, store);
+        Rating rating = getRating(user.getId(), store.getId());
 
         store.removeRating(rating.getRating());
         ratingRepository.delete(rating);
@@ -73,8 +73,8 @@ public class RatingService {
         return RatingDeleteResponseDto.fromRating(rating.getId());
     }
 
-    private Rating getRating(User user, Store store) {
-        return ratingRepository.findByUserAndStore(user, store)
+    private Rating getRating(Long userId, Long storeId) {
+        return ratingRepository.findByUserIdAndStoreId(userId, storeId)
                 .orElseThrow(() -> new HandledException(ErrorCode.RATING_NOT_FOUND));
     }
 

--- a/src/test/java/org/example/tablenow/domain/rating/service/RatingServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/rating/service/RatingServiceTest.java
@@ -1,0 +1,267 @@
+package org.example.tablenow.domain.rating.service;
+
+import org.example.tablenow.domain.rating.dto.request.RatingRequestDto;
+import org.example.tablenow.domain.rating.dto.response.RatingCreateResponseDto;
+import org.example.tablenow.domain.rating.dto.response.RatingDeleteResponseDto;
+import org.example.tablenow.domain.rating.dto.response.RatingUpdateResponseDto;
+import org.example.tablenow.domain.rating.entity.Rating;
+import org.example.tablenow.domain.rating.repository.RatingRepository;
+import org.example.tablenow.domain.reservation.service.ReservationService;
+import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.store.service.StoreService;
+import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.domain.user.enums.UserRole;
+import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class RatingServiceTest {
+
+    @Mock
+    private RatingRepository ratingRepository;
+    @Mock
+    private StoreService storeService;
+    @Mock
+    private ReservationService reservationService;
+    @InjectMocks
+    private RatingService ratingService;
+
+    Long userId = 1L;
+    AuthUser authUser = new AuthUser(userId, "user@a.com", UserRole.ROLE_USER, "일반");
+    User user = User.fromAuthUser(authUser);
+
+    Long storeId = 1L;
+    Double averageRating = 5.0;
+    int ratingCount = 2;
+    Store store = Store.builder().id(storeId).averageRating(averageRating).ratingCount(ratingCount).build();
+
+    Long ratingId = 1L;
+    Rating rating = Rating.builder().id(1L).user(user).store(store).rating(4).build();
+
+    @Nested
+    class 평점_등록 {
+        RatingRequestDto dto = new RatingRequestDto(4);
+
+        @Test
+        void 존재하지_않는_가게의_평점_등록_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willThrow(new HandledException(ErrorCode.STORE_NOT_FOUND));
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.createRating(authUser, storeId, dto);
+            });
+
+            assertEquals(exception.getMessage(), ErrorCode.STORE_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 평점_중복_등록_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.existsByUserAndStore(anyLong(), anyLong())).willReturn(true);
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.createRating(authUser, storeId, dto);
+            });
+
+            assertEquals(exception.getMessage(), ErrorCode.RATING_ALREADY_EXISTS.getDefaultMessage());
+        }
+
+        @Test
+        void 해당_가게에_유저가_등록한_완료_예약이_없을_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.existsByUserAndStore(anyLong(), anyLong())).willReturn(false);
+            willThrow(new HandledException(ErrorCode.RATING_RESERVATION_NOT_FOUND))
+                    .given(reservationService).validateCreateRating(anyLong(), anyLong());
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.createRating(authUser, storeId, dto);
+            });
+
+            assertEquals(exception.getMessage(), ErrorCode.RATING_RESERVATION_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 등록_성공() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.existsByUserAndStore(anyLong(), anyLong())).willReturn(false);
+            given(ratingRepository.save(any(Rating.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            RatingCreateResponseDto response = ratingService.createRating(authUser, storeId, dto);
+
+            // then
+            verify(reservationService).validateCreateRating(anyLong(), anyLong());
+            assertAll(
+                    () -> assertNotNull(response),
+                    () -> assertEquals(response.getUserId(), userId),
+                    () -> assertEquals(response.getStoreId(), storeId),
+                    () -> assertEquals(response.getRating(), dto.getRating()),
+                    () -> assertEquals(store.getRatingCount(), ratingCount + 1),
+                    () -> assertEquals(store.getAverageRating(),
+                            ((averageRating * ratingCount) + dto.getRating()) / store.getRatingCount())
+            );
+        }
+    }
+
+    @Nested
+    class 평점_수정 {
+
+        RatingRequestDto dto = new RatingRequestDto(4);
+
+        @Test
+        void 존재하지_않는_가게의_평점_수정_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willThrow(new HandledException(ErrorCode.STORE_NOT_FOUND));
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.updateRating(authUser, storeId, dto);
+            });
+
+            verify(storeService).getStore(anyLong());
+            assertEquals(exception.getMessage(), ErrorCode.STORE_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 존재하지_않는_평점_수정_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.findByUserIdAndStoreId(anyLong(), anyLong())).willReturn(Optional.empty());
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.updateRating(authUser, storeId, dto);
+            });
+
+            assertEquals(exception.getMessage(), ErrorCode.RATING_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 평점_등록_수가_0_인_경우_예외_발생() {
+            // given
+            ReflectionTestUtils.setField(store, "ratingCount", 0);
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.findByUserIdAndStoreId(anyLong(), anyLong())).willReturn(Optional.of(rating));
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.updateRating(authUser, storeId, dto);
+            });
+
+            assertEquals(exception.getMessage(), ErrorCode.CONFLICT.getDefaultMessage());
+        }
+
+        @Test
+        void 수정_성공() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.findByUserIdAndStoreId(anyLong(), anyLong())).willReturn(Optional.of(rating));
+
+            // when
+            RatingUpdateResponseDto response = ratingService.updateRating(authUser, storeId, dto);
+
+            // then
+            assertAll(
+                    () -> assertNotNull(response),
+                    () -> assertEquals(response.getUserId(), userId),
+                    () -> assertEquals(response.getStoreId(), storeId),
+                    () -> assertEquals(response.getRating(), dto.getRating()),
+                    () -> assertEquals(store.getRatingCount(), ratingCount),
+                    () -> assertEquals(store.getAverageRating(),
+                            ((averageRating * ratingCount) - rating.getRating() + dto.getRating()) / ratingCount)
+            );
+        }
+    }
+
+    @Nested
+    class 평점_삭제 {
+
+        @Test
+        void 존재하지_않는_가게의_평점_삭제_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willThrow(new HandledException(ErrorCode.STORE_NOT_FOUND));
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.deleteRating(authUser, storeId);
+            });
+
+            verify(storeService).getStore(anyLong());
+            assertEquals(exception.getMessage(), ErrorCode.STORE_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 존재하지_않는_평점_삭제_시_예외_발생() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.findByUserIdAndStoreId(anyLong(), anyLong())).willReturn(Optional.empty());
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () -> {
+                ratingService.deleteRating(authUser, storeId);
+            });
+
+            assertEquals(exception.getMessage(), ErrorCode.RATING_NOT_FOUND.getDefaultMessage());
+        }
+
+        @Test
+        void 전체_평점_삭제_시_가게_평점_0_초기화() {
+            // given
+            ReflectionTestUtils.setField(store, "ratingCount", 1);
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.findByUserIdAndStoreId(anyLong(), anyLong())).willReturn(Optional.of(rating));
+
+            // when
+            RatingDeleteResponseDto response = ratingService.deleteRating(authUser, storeId);
+
+            // then
+            assertAll(
+                    () -> assertNotNull(response),
+                    () -> assertEquals(response.getRatingId(), ratingId),
+                    () -> assertEquals(store.getRatingCount(), 0),
+                    () -> assertEquals(store.getAverageRating(), 0.0)
+            );
+        }
+
+        @Test
+        void 삭제_성공() {
+            // given
+            given(storeService.getStore(anyLong())).willReturn(store);
+            given(ratingRepository.findByUserIdAndStoreId(anyLong(), anyLong())).willReturn(Optional.of(rating));
+
+            // when
+            RatingDeleteResponseDto response = ratingService.deleteRating(authUser, storeId);
+
+            // then
+            assertAll(
+                    () -> assertNotNull(response),
+                    () -> assertEquals(response.getRatingId(), ratingId),
+                    () -> assertEquals(store.getRatingCount(), ratingCount - 1),
+                    () -> assertEquals(store.getAverageRating(),
+                            ((averageRating * ratingCount) - rating.getRating()) / (ratingCount - 1))
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #104

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
* 평점 등록
`예외`: 존재하지 않는 가게, 평점을 중복 등록하는 경우, COMPLETED 상태의 예약이 존재하지 않는 경우, 
`성공`
* 평점 수정
`예외`: 존재하지 않는 가게, 존재하지 않는 평점, 평점 등록 수가 0인 경우
`성공`
* 평점 삭제
`예외`: 존재하지 않는 가게, 존재하지 않는 평점
`성공`: 전체 평점 삭제 시 평점 초기화 및 삭제 성공

- [X] 평점 등록
- [X] 평점 수정
- [X] 평점 삭제



## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
테스트 진행 중 findByUserIdAndStoreId() 조회 쿼리의 @EntityGraph 설정으로
불필요한 left join 이 발생하고 있는 것을 확인하여 해당 부분 같이 수정하였습니다. 
![image](https://github.com/user-attachments/assets/7affe9e1-1290-407b-ad1c-2da07bedf200)


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/aae38d96-b77c-435e-94f0-4d598749cc40)
