### PR TITLE
[refactor] 가게, 카테고리 API 코드 개선

### DIFF
--- a/src/main/java/org/example/tablenow/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/example/tablenow/domain/category/controller/CategoryController.java
@@ -22,8 +22,8 @@ public class CategoryController {
     // 카테고리 등록
     @Secured("ROLE_ADMIN")
     @PostMapping("/v1/admin/categories")
-    public ResponseEntity<CategoryResponseDto> saveCategory(@Valid @RequestBody CategoryRequestDto requestDto) {
-        return ResponseEntity.ok(categoryService.saveCategory(requestDto));
+    public ResponseEntity<CategoryResponseDto> createCategory(@Valid @RequestBody CategoryRequestDto requestDto) {
+        return ResponseEntity.ok(categoryService.createCategory(requestDto));
     }
 
     // 카테고리 수정

--- a/src/main/java/org/example/tablenow/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/org/example/tablenow/domain/category/repository/CategoryRepository.java
@@ -2,9 +2,15 @@ package org.example.tablenow.domain.category.repository;
 
 import org.example.tablenow.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    Optional<Category> findByName(String name);
+    @Query("""
+            SELECT COUNT(c) > 0
+            FROM Category c
+            WHERE c.name = :name
+            """)
+    boolean existsByName(String name);
 }

--- a/src/main/java/org/example/tablenow/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/tablenow/domain/category/service/CategoryService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,8 +22,8 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public CategoryResponseDto saveCategory(CategoryRequestDto requestDto) {
-        validateExistCategory(requestDto);
+    public CategoryResponseDto createCategory(CategoryRequestDto requestDto) {
+        validateExistCategoryName(requestDto.getName());
         Category category = Category.builder().name(requestDto.getName()).build();
         Category savedCategory = categoryRepository.save(category);
         return CategoryResponseDto.fromCategory(savedCategory);
@@ -33,7 +32,7 @@ public class CategoryService {
     @Transactional
     public CategoryResponseDto updateCategory(Long id, CategoryRequestDto requestDto) {
         Category category = findCategory(id);
-        validateExistCategory(requestDto);
+        validateExistCategoryName(requestDto.getName());
         category.updateName(requestDto.getName());
         return CategoryResponseDto.fromCategory(category);
     }
@@ -56,13 +55,9 @@ public class CategoryService {
                 .orElseThrow(() -> new HandledException(ErrorCode.CATEGORY_NOT_FOUND));
     }
 
-    public Optional<Category> findCategoryByName(String name) {
-        return categoryRepository.findByName(name);
-    }
-
-    private void validateExistCategory(CategoryRequestDto requestDto) {
-        findCategoryByName(requestDto.getName()).ifPresent(it -> {
+    private void validateExistCategoryName(String name) {
+        if (categoryRepository.existsByName(name)) {
             throw new HandledException(ErrorCode.CATEGORY_ALREADY_EXISTS);
-        });
+        }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/controller/StoreController.java
+++ b/src/main/java/org/example/tablenow/domain/store/controller/StoreController.java
@@ -26,9 +26,9 @@ public class StoreController {
     // 가게 등록
     @Secured(UserRole.Authority.OWNER)
     @PostMapping("/v1/owner/stores")
-    public ResponseEntity<StoreCreateResponseDto> saveStore(@AuthenticationPrincipal AuthUser authUser,
-                                                            @Valid @RequestBody StoreCreateRequestDto requestDto) {
-        return ResponseEntity.ok(storeService.saveStore(authUser, requestDto));
+    public ResponseEntity<StoreCreateResponseDto> createStore(@AuthenticationPrincipal AuthUser authUser,
+                                                              @Valid @RequestBody StoreCreateRequestDto requestDto) {
+        return ResponseEntity.ok(storeService.createStore(authUser, requestDto));
     }
 
     // 내 가게 목록 조회

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreCreateResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreCreateResponseDto.java
@@ -18,15 +18,15 @@ public class StoreCreateResponseDto {
     private final String description;
     private final String address;
     private final String imageUrl;
-    private final int capacity;
+    private final Integer capacity;
     private final LocalTime startTime;
     private final LocalTime endTime;
-    private final int deposit;
+    private final Integer deposit;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
 
     @Builder
-    public StoreCreateResponseDto(Long storeId, String name, Long userId, Long categoryId, String categoryName, String description, String address, String imageUrl, int capacity, LocalTime startTime, LocalTime endTime, int deposit, LocalDateTime createdAt) {
+    public StoreCreateResponseDto(Long storeId, String name, Long userId, Long categoryId, String categoryName, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit, LocalDateTime createdAt) {
         this.storeId = storeId;
         this.name = name;
         this.userId = userId;

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreResponseDto.java
@@ -16,13 +16,13 @@ public class StoreResponseDto {
     private final String description;
     private final String address;
     private final String imageUrl;
-    private final int capacity;
+    private final Integer capacity;
     private final LocalTime startTime;
     private final LocalTime endTime;
-    private final int deposit;
+    private final Integer deposit;
 
     @Builder
-    public StoreResponseDto(Long storeId, String name, Long userId, Long categoryId, String categoryName, String description, String address, String imageUrl, int capacity, LocalTime startTime, LocalTime endTime, int deposit) {
+    public StoreResponseDto(Long storeId, String name, Long userId, Long categoryId, String categoryName, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit) {
         this.storeId = storeId;
         this.name = name;
         this.userId = userId;

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreUpdateResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreUpdateResponseDto.java
@@ -18,15 +18,15 @@ public class StoreUpdateResponseDto {
     private final String description;
     private final String address;
     private final String imageUrl;
-    private final int capacity;
+    private final Integer capacity;
     private final LocalTime startTime;
     private final LocalTime endTime;
-    private final int deposit;
+    private final Integer deposit;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime updatedAt;
 
     @Builder
-    public StoreUpdateResponseDto(Long storeId, String name, Long userId, Long categoryId, String categoryName, String description, String address, String imageUrl, int capacity, LocalTime startTime, LocalTime endTime, int deposit, LocalDateTime updatedAt) {
+    public StoreUpdateResponseDto(Long storeId, String name, Long userId, Long categoryId, String categoryName, String description, String address, String imageUrl, Integer capacity, LocalTime startTime, LocalTime endTime, Integer deposit, LocalDateTime updatedAt) {
         this.storeId = storeId;
         this.name = name;
         this.userId = userId;

--- a/src/main/java/org/example/tablenow/domain/store/entity/Store.java
+++ b/src/main/java/org/example/tablenow/domain/store/entity/Store.java
@@ -30,9 +30,9 @@ public class Store extends TimeStamped {
     private String address;
     private String imageUrl;
     @Min(0)
-    private int capacity;
+    private Integer capacity;
     @Min(0)
-    private int deposit;
+    private Integer deposit;
     private Double averageRating = 0.0;
     private Integer ratingCount = 0;
     @Column(nullable = false)
@@ -81,11 +81,11 @@ public class Store extends TimeStamped {
         this.imageUrl = imageUrl;
     }
 
-    public void updateCapacity(int capacity) {
+    public void updateCapacity(Integer capacity) {
         this.capacity = capacity;
     }
 
-    public void updateDeposit(int deposit) {
+    public void updateDeposit(Integer deposit) {
         this.deposit = deposit;
     }
 
@@ -114,16 +114,16 @@ public class Store extends TimeStamped {
         return reservedCount < this.capacity;
     }
 
-    public void applyRating(int rating) {
-        int newRatingCount = this.ratingCount + 1;
+    public void applyRating(Integer rating) {
+        Integer newRatingCount = this.ratingCount + 1;
         Double newAverageRating = ((this.averageRating * this.ratingCount) + rating) / newRatingCount;
 
         this.ratingCount = newRatingCount;
         this.averageRating = newAverageRating;
     }
 
-    public void removeRating(int rating) {
-        int newRatingCount = this.ratingCount - 1;
+    public void removeRating(Integer rating) {
+        Integer newRatingCount = this.ratingCount - 1;
 
         if (newRatingCount <= 0) {
             this.ratingCount = 0;
@@ -136,7 +136,7 @@ public class Store extends TimeStamped {
         this.averageRating = newAverageRating;
     }
 
-    public void updateRating(int oldRating, int newRating) {
+    public void updateRating(Integer oldRating, Integer newRating) {
         if (this.ratingCount == 0) {
             throw new HandledException(ErrorCode.CONFLICT);
         }

--- a/src/main/java/org/example/tablenow/domain/store/entity/Store.java
+++ b/src/main/java/org/example/tablenow/domain/store/entity/Store.java
@@ -49,7 +49,7 @@ public class Store extends TimeStamped {
     private LocalDateTime deletedAt;
 
     @Builder
-    private Store(Long id, String name, String description, String address, String imageUrl, int capacity, int deposit, Double averageRating, Integer ratingCount, LocalTime startTime, LocalTime endTime, User user, Category category) {
+    private Store(Long id, String name, String description, String address, String imageUrl, Integer capacity, Integer deposit, Double averageRating, Integer ratingCount, LocalTime startTime, LocalTime endTime, User user, Category category) {
         this.id = id;
         this.name = name;
         this.description = description;

--- a/src/main/java/org/example/tablenow/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/StoreService.java
@@ -49,7 +49,7 @@ public class StoreService {
     private static final DateTimeFormatter TIME_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
 
     @Transactional
-    public StoreCreateResponseDto saveStore(AuthUser authUser, StoreCreateRequestDto request) {
+    public StoreCreateResponseDto createStore(AuthUser authUser, StoreCreateRequestDto request) {
         User user = User.fromAuthUser(authUser);
 
         Category category = categoryService.findCategory(request.getCategoryId());

--- a/src/test/java/org/example/tablenow/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/category/service/CategoryServiceTest.java
@@ -48,11 +48,11 @@ public class CategoryServiceTest {
         @Test
         void 중복_카테고리_등록_시_예외_발생() {
             // given
-            given(categoryRepository.findByName(anyString())).willReturn(Optional.of(category));
+            given(categoryRepository.existsByName(anyString())).willReturn(true);
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    categoryService.saveCategory(dto)
+                    categoryService.createCategory(dto)
             );
             assertEquals(exception.getMessage(), ErrorCode.CATEGORY_ALREADY_EXISTS.getDefaultMessage());
         }
@@ -60,11 +60,11 @@ public class CategoryServiceTest {
         @Test
         void 등록_성공() {
             // given
-            given(categoryRepository.findByName(anyString())).willReturn(Optional.empty());
+            given(categoryRepository.existsByName(anyString())).willReturn(false);
             given(categoryRepository.save(any(Category.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            CategoryResponseDto response = categoryService.saveCategory(dto);
+            CategoryResponseDto response = categoryService.createCategory(dto);
 
             // then
             assertNotNull(response);
@@ -93,7 +93,7 @@ public class CategoryServiceTest {
             // given
             ReflectionTestUtils.setField(dto, "name", categoryName);
             given(categoryRepository.findById(anyLong())).willReturn(Optional.of(category));
-            given(categoryRepository.findByName(anyString())).willReturn(Optional.of(category));
+            given(categoryRepository.existsByName(anyString())).willReturn(true);
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
@@ -108,7 +108,7 @@ public class CategoryServiceTest {
             String requestName = "분식";
             ReflectionTestUtils.setField(dto, "name", requestName);
             given(categoryRepository.findById(anyLong())).willReturn(Optional.of(category));
-            given(categoryRepository.findByName(anyString())).willReturn(Optional.empty());
+            given(categoryRepository.existsByName(anyString())).willReturn(false);
 
             // when
             CategoryResponseDto response = categoryService.updateCategory(categoryId, dto);

--- a/src/test/java/org/example/tablenow/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/store/service/StoreServiceTest.java
@@ -105,7 +105,7 @@ public class StoreServiceTest {
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    storeService.saveStore(authOwner, dto)
+                    storeService.createStore(authOwner, dto)
             );
             assertEquals(exception.getMessage(), ErrorCode.CATEGORY_NOT_FOUND.getDefaultMessage());
         }
@@ -118,7 +118,7 @@ public class StoreServiceTest {
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    storeService.saveStore(authOwner, dto)
+                    storeService.createStore(authOwner, dto)
             );
             assertEquals(exception.getMessage(), ErrorCode.STORE_BAD_REQUEST_TIME.getDefaultMessage());
         }
@@ -131,7 +131,7 @@ public class StoreServiceTest {
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    storeService.saveStore(authOwner, dto)
+                    storeService.createStore(authOwner, dto)
             );
             assertEquals(exception.getMessage(), ErrorCode.STORE_EXCEED_MAX.getDefaultMessage());
         }
@@ -144,7 +144,7 @@ public class StoreServiceTest {
             given(storeRepository.save(any(Store.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            StoreCreateResponseDto response = storeService.saveStore(authOwner, dto);
+            StoreCreateResponseDto response = storeService.createStore(authOwner, dto);
 
             // then
             assertNotNull(response);


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #108


## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
DTO 객체의 필드는 기본형 타입 대신 Wrapper 클래스 사용 (예: int -> Integer)
생성(Create) API : saveEntity() -> createEntity()
중복 검사 메서드: boolean existsEntity() 으로 중복 검사

- [X] 가게 등록 API 메서드명 수정, 카테고리 등록 API 메서드명 수정
- [X] DTO 필드 데이터타입 Wrapper 클래스 변경
- [X] 카테고리 중복 검사 메서드: Optional -> boolean 변경
- [X] 테스트코드 수정


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
코드 수정 후 postman 테스트 확인 및 단위 테스트 검증 완료했습니다.

* 카테고리 등록
![스크린샷 2025-04-15 오후 1 21 12](https://github.com/user-attachments/assets/b9b4e0c2-152b-4dab-9cd1-3e4945b7286f)
* 가게 등록
![스크린샷 2025-04-15 오후 1 27 19](https://github.com/user-attachments/assets/4da01308-d352-46ce-a1f9-81ed678f10ff)

