### PR TITLE
[feat] 예약 생성 API Redisson 락 적용

### DIFF
--- a/src/main/java/org/example/tablenow/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/controller/ReservationController.java
@@ -35,6 +35,14 @@ public class ReservationController {
         return ResponseEntity.ok(reservationService.makeReservation(authUser, request));
     }
 
+    @PostMapping("/v2/reservations")
+    public ResponseEntity<ReservationResponseDto> makeReservationWithLock(
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody ReservationRequestDto request
+    ) {
+        return ResponseEntity.ok(reservationService.makeReservationWithLock(authUser, request));
+    }
+
     @PatchMapping("/v1/reservations/{id}")
     public ResponseEntity<ReservationResponseDto> updateReservation(
             @AuthenticationPrincipal AuthUser authUser,

--- a/src/main/java/org/example/tablenow/domain/reservation/dto/response/ReservationResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/dto/response/ReservationResponseDto.java
@@ -13,17 +13,19 @@ public class ReservationResponseDto {
     private final Long storeId;
     private final String storeName;
     private final LocalDateTime reservedAt;
+    private final LocalDateTime remindAt;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final ReservationStatus status;
 
     @Builder
-    private ReservationResponseDto(Long reservationId, Long storeId, String storeName, LocalDateTime reservedAt,
+    private ReservationResponseDto(Long reservationId, Long storeId, String storeName, LocalDateTime reservedAt, LocalDateTime remindAt,
                                    LocalDateTime createdAt, LocalDateTime updatedAt, ReservationStatus status) {
         this.reservationId = reservationId;
         this.storeId = storeId;
         this.storeName = storeName;
         this.reservedAt = reservedAt;
+        this.remindAt = remindAt;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.status = status;
@@ -35,6 +37,7 @@ public class ReservationResponseDto {
                 .storeId(reservation.getStore().getId())
                 .storeName(reservation.getStore().getName())
                 .reservedAt(reservation.getReservedAt())
+                .remindAt(reservation.getRemindAt())
                 .createdAt(reservation.getCreatedAt())
                 .updatedAt(reservation.getUpdatedAt())
                 .status(reservation.getStatus())

--- a/src/main/java/org/example/tablenow/domain/reservation/entity/Reservation.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/entity/Reservation.java
@@ -33,6 +33,7 @@ public class Reservation extends TimeStamped {
     private ReservationStatus status;
 
     private LocalDateTime reservedAt;
+    private LocalDateTime remindAt;
     private LocalDateTime deletedAt;
 
     @Builder
@@ -41,6 +42,7 @@ public class Reservation extends TimeStamped {
         this.user = user;
         this.store = store;
         this.reservedAt = reservedAt;
+        this.remindAt = reservedAt.minusDays(1);
         this.status = ReservationStatus.RESERVED;
     }
 

--- a/src/main/java/org/example/tablenow/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/repository/ReservationRepository.java
@@ -22,7 +22,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
           and r.status <> 'CANCELED'
         """)
     boolean isReservedStatusInUse(Long storeId, LocalDateTime reservedAt);
-
+    boolean existsByUserIdAndStoreIdAndReservedAt(Long userId, Long storeId, LocalDateTime reservedAt);
     boolean existsByStoreIdAndReservedAtAndIdNot(Long storeId, LocalDateTime reservedAt, Long id);
 
     @Query("""

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     RESERVATION_TIME_INVALID(HttpStatus.BAD_REQUEST, "예약 시간은 정각 또는 30분 단위여야 합니다."),
     RESERVATION_STATUS_INVALID(HttpStatus.BAD_REQUEST, "예약 상태가 유효하지 않습니다."),
     RESERVATION_STATUS_UPDATE_FORBIDDEN(HttpStatus.BAD_REQUEST, "예약 상태에서만 변경할 수 있습니다."),
+    RESERVATION_LOCK_TIMEOUT(HttpStatus.CONFLICT, "예약 신청 대기 중 시간이 초과되었습니다."),
 
     // EVENT
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트가 존재하지 않습니다."),


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #128 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] `makeReservationWithLock()` 메서드 추가
- [X] 가게 ID + 예약일 기반 Lock Key 설정
- [X] `Reservation` 엔티티에 `remindAt` 필드 추가
- [X] `ErrorCode`에 `RESERVATION_LOCK_TIMEOUT` 추가
- [X] 같은 유저가, 같은 시간에, 같은 가게를 예약하는 경우 예외 처리(`existsByUserIdAndStoreIdAndReservedAt()` 추가)


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- - 기존 `isReservedStatusInUse()`는 "같은 시간대에 예약이 존재하면 무조건 예외"를 발생시켜, 실제로는 **동일 시간대 예약이 1건만 가능**한 구조였습니다.
   - 가게 정원이 **하루 단위**이므로, 중복 검증 시 `boolean existsByUserIdAndStoreIdAndReservedAt(Long userId, Long storeId, LocalDateTime reservedAt);` 를 사용하도록 수정해 **동일 유저가 같은 시간에 예약했는지만** 검증했습니다.
   - 따라서 유저 단위 중복만 막고, 그날 하루 정원만큼 예약 가능한 구조입니다. 수정해야할 부분이 있으면 말씀해주세요!
- 예약 API는 이벤트 API와 달리 선착순이나 순위가 없고, 몰림 현상이 이벤트보다 적어 ZSet을 사용하지 않았습니다.

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
### 가게 정원 20명, 200명 같은 시간대 예약 테스트
![image](https://github.com/user-attachments/assets/54a7acd8-9caa-465a-937c-54ab8b62ad75)

### 정원이 꽉 찬 상태에서 예약 시도할 때
![image](https://github.com/user-attachments/assets/3f6c5d1c-9ce6-4a1f-932e-c0f7538e6c44)

### 정원이 남았지만 이미 예약한 유저일 때
![image](https://github.com/user-attachments/assets/6ddbad8c-4b4a-4134-92e1-2f384061ffc4)
