### PR TITLE
[refactor] Redis/OAuth/S3 예외 처리 및 테스트 코드 개선

### DIFF
--- a/src/main/java/org/example/tablenow/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/org/example/tablenow/domain/auth/service/KakaoAuthService.java
@@ -40,6 +40,7 @@ public class KakaoAuthService {
     private final WebClient webClient;
     private final OAuthProperties oAuthProperties;
     private final KakaoOAuthProperties kakaoOAuthProperties;
+    private final OAuthResponseParser oAuthResponseParser;
 
     @Transactional
     public TokenResponse login(String code) {
@@ -117,7 +118,7 @@ public class KakaoAuthService {
                         return Mono.error(new HandledException(ErrorCode.OAUTH_PROVIDER_SERVER_ERROR));
                     })
                     .bodyToMono(String.class)
-                    .map(OAuthResponseParser::extractAccessToken)
+                    .map(oAuthResponseParser::extractAccessToken)
                     .block();
         } catch (WebClientRequestException e) {
             log.error("[OAuth] 카카오 WebClient 요청 실패", e);

--- a/src/main/java/org/example/tablenow/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/org/example/tablenow/domain/auth/service/KakaoAuthService.java
@@ -1,9 +1,8 @@
 package org.example.tablenow.domain.auth.service;
 
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.auth.dto.response.TokenResponse;
 import org.example.tablenow.domain.auth.oAuth.config.KakaoOAuthProperties;
 import org.example.tablenow.domain.auth.oAuth.config.OAuthProperties;
@@ -14,11 +13,13 @@ import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.domain.user.repository.UserRepository;
 import org.example.tablenow.global.constant.OAuthConstants;
+import org.example.tablenow.global.constant.SecurityConstants;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.example.tablenow.global.constant.SecurityConstants;
+import org.example.tablenow.global.util.OAuthResponseParser;
 import org.example.tablenow.global.util.PhoneNumberNormalizer;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +27,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.publisher.Mono;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class KakaoAuthService {
@@ -34,7 +38,6 @@ public class KakaoAuthService {
     private final UserRepository userRepository;
     private final TokenService tokenService;
     private final WebClient webClient;
-    private final ObjectMapper objectMapper;
     private final OAuthProperties oAuthProperties;
     private final KakaoOAuthProperties kakaoOAuthProperties;
 
@@ -69,14 +72,26 @@ public class KakaoAuthService {
         formData.add(OAuthConstants.TARGET_ID_TYPE, OAuthConstants.USER_ID);
         formData.add(OAuthConstants.TARGET_ID, kakaoUserId);
 
-        webClient.post()
-                .uri(kakaoOAuthProperties.getUnlinkUri())
-                .header(HttpHeaders.AUTHORIZATION, OAuthConstants.KAKAO_ADMIN_AUTH_PREFIX + kakaoOAuthProperties.getAdminKey())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(BodyInserters.fromFormData(formData))
-                .retrieve()
-                .bodyToMono(Void.class)
-                .block();
+        try {
+            webClient.post()
+                    .uri(kakaoOAuthProperties.getUnlinkUri())
+                    .header(HttpHeaders.AUTHORIZATION, OAuthConstants.KAKAO_ADMIN_AUTH_PREFIX + kakaoOAuthProperties.getAdminKey())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(formData))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, res -> {
+                        log.warn("[OAuth] 카카오 계정 연결 해제 실패: {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_USER_UNLINK_REQUEST_FAILED));
+                    })
+                    .bodyToMono(Void.class)
+                    .block();
+        } catch (WebClientRequestException e) {
+            log.error("[OAuth] 카카오 계정 해제 WebClient 요청 실패", e);
+            throw new HandledException(ErrorCode.OAUTH_PROVIDER_UNREACHABLE);
+        } catch (Exception e) {
+            log.error("[OAuth] 카카오 계정 해제 중 알 수 없는 오류", e);
+            throw new HandledException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     private String getKakaoAccessToken(String code) {
@@ -87,31 +102,54 @@ public class KakaoAuthService {
         formData.add(OAuthConstants.GRANT_TYPE, oAuthProperties.getRegistration().getKakao().getAuthorizationGrantType());
         formData.add(OAuthConstants.CODE, code);
 
-        return webClient.post()
-                .uri(oAuthProperties.getProvider().getKakao().getTokenUri())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(BodyInserters.fromFormData(formData))
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(this::extractAccessToken)
-                .block();
+        try {
+            return webClient.post()
+                    .uri(oAuthProperties.getProvider().getKakao().getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(formData))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, res -> {
+                        log.warn("[OAuth] 카카오 인가코드 오류 (4xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_TOKEN_REQUEST_FAILED));
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, res -> {
+                        log.error("[OAuth] 카카오 인증 서버 오류 (5xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_PROVIDER_SERVER_ERROR));
+                    })
+                    .bodyToMono(String.class)
+                    .map(OAuthResponseParser::extractAccessToken)
+                    .block();
+        } catch (WebClientRequestException e) {
+            log.error("[OAuth] 카카오 WebClient 요청 실패", e);
+            throw new HandledException(ErrorCode.OAUTH_PROVIDER_UNREACHABLE);
+        } catch (Exception e) {
+            log.error("[OAuth] 카카오 토큰 요청 중 알 수 없는 오류", e);
+            throw new HandledException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     private KakaoUserInfoResponse getKakaoUserInfo(String accessToken) {
-        return webClient.get()
-                .uri(oAuthProperties.getProvider().getKakao().getUserInfoUri())
-                .header(HttpHeaders.AUTHORIZATION, SecurityConstants.BEARER_PREFIX + accessToken)
-                .retrieve()
-                .bodyToMono(KakaoUserInfoResponse.class) // 응답 Body 객체 매핑: JSON -> KakaoUserInfoResponse 클래스 인스턴스로 역직렬화
-                .block();
-    }
-
-    private String extractAccessToken(String response) {
         try {
-            JsonNode jsonNode = objectMapper.readTree(response);
-            return jsonNode.get(OAuthConstants.ACCESS_TOKEN).asText();
+            return webClient.get()
+                    .uri(oAuthProperties.getProvider().getKakao().getUserInfoUri())
+                    .header(HttpHeaders.AUTHORIZATION, SecurityConstants.BEARER_PREFIX + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, res -> {
+                        log.warn("[OAuth] 카카오 사용자 정보 요청 실패 (4xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_USER_INFO_REQUEST_FAILED));
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, res -> {
+                        log.error("[OAuth] 카카오 사용자 정보 요청 서버 오류 (5xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_PROVIDER_SERVER_ERROR));
+                    })
+                    .bodyToMono(KakaoUserInfoResponse.class) // 응답 Body 객체 매핑: JSON -> KakaoUserInfoResponse 클래스 인스턴스로 역직렬화
+                    .block();
+        } catch (WebClientRequestException e) {
+            log.error("[OAuth] 카카오 사용자 정보 요청 WebClient 실패", e);
+            throw new HandledException(ErrorCode.OAUTH_PROVIDER_UNREACHABLE);
         } catch (Exception e) {
-            throw new HandledException(ErrorCode.FAILED_TO_PARSE_OAUTH_TOKEN);
+            log.error("[OAuth] 카카오 사용자 정보 요청 중 알 수 없는 오류", e);
+            throw new HandledException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/org/example/tablenow/domain/auth/service/NaverAuthService.java
+++ b/src/main/java/org/example/tablenow/domain/auth/service/NaverAuthService.java
@@ -37,6 +37,7 @@ public class NaverAuthService {
     private final TokenService tokenService;
     private final WebClient webClient;
     private final OAuthProperties oAuthProperties;
+    private final OAuthResponseParser oAuthResponseParser;
 
     @Transactional
     public TokenResponse login(String code) {
@@ -87,7 +88,7 @@ public class NaverAuthService {
                         return Mono.error(new HandledException(ErrorCode.OAUTH_PROVIDER_SERVER_ERROR));
                     })
                     .bodyToMono(String.class)
-                    .map(OAuthResponseParser::extractAccessToken)
+                    .map(oAuthResponseParser::extractAccessToken)
                     .block();
         } catch (WebClientRequestException e) {
             log.error("[OAuth] 네이버 WebClient 요청 실패", e);

--- a/src/main/java/org/example/tablenow/domain/auth/service/NaverAuthService.java
+++ b/src/main/java/org/example/tablenow/domain/auth/service/NaverAuthService.java
@@ -1,8 +1,7 @@
 package org.example.tablenow.domain.auth.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.auth.dto.response.TokenResponse;
 import org.example.tablenow.domain.auth.oAuth.config.OAuthProperties;
 import org.example.tablenow.domain.auth.oAuth.config.OAuthProvider;
@@ -12,11 +11,13 @@ import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.domain.user.repository.UserRepository;
 import org.example.tablenow.global.constant.OAuthConstants;
+import org.example.tablenow.global.constant.SecurityConstants;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.example.tablenow.global.constant.SecurityConstants;
+import org.example.tablenow.global.util.OAuthResponseParser;
 import org.example.tablenow.global.util.PhoneNumberNormalizer;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +25,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.publisher.Mono;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class NaverAuthService {
@@ -32,7 +36,6 @@ public class NaverAuthService {
     private final UserRepository userRepository;
     private final TokenService tokenService;
     private final WebClient webClient;
-    private final ObjectMapper objectMapper;
     private final OAuthProperties oAuthProperties;
 
     @Transactional
@@ -69,31 +72,54 @@ public class NaverAuthService {
         formData.add(OAuthConstants.GRANT_TYPE, oAuthProperties.getRegistration().getNaver().getAuthorizationGrantType());
         formData.add(OAuthConstants.CODE, code);
 
-        return webClient.post()
-                .uri(oAuthProperties.getProvider().getNaver().getTokenUri())
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .body(BodyInserters.fromFormData(formData))
-                .retrieve()
-                .bodyToMono(String.class)
-                .map(this::extractAccessToken)
-                .block();
+        try {
+            return webClient.post()
+                    .uri(oAuthProperties.getProvider().getNaver().getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(formData))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, res -> {
+                        log.warn("[OAuth] 네이버 인가코드 오류 (4xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_TOKEN_REQUEST_FAILED));
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, res -> {
+                        log.error("[OAuth] 네이버 인증 서버 오류 (5xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_PROVIDER_SERVER_ERROR));
+                    })
+                    .bodyToMono(String.class)
+                    .map(OAuthResponseParser::extractAccessToken)
+                    .block();
+        } catch (WebClientRequestException e) {
+            log.error("[OAuth] 네이버 WebClient 요청 실패", e);
+            throw new HandledException(ErrorCode.OAUTH_PROVIDER_UNREACHABLE);
+        } catch (Exception e) {
+            log.error("[OAuth] 네이버 토큰 요청 중 알 수 없는 오류", e);
+            throw new HandledException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     private NaverUserInfoResponse getNaverUserInfo(String accessToken) {
-        return webClient.get()
-                .uri(oAuthProperties.getProvider().getNaver().getUserInfoUri())
-                .header(HttpHeaders.AUTHORIZATION, SecurityConstants.BEARER_PREFIX + accessToken)
-                .retrieve()
-                .bodyToMono(NaverUserInfoResponse.class) // 응답 Body 객체 매핑: JSON -> NaverUserInfoResponse 클래스 인스턴스로 역직렬화
-                .block();
-    }
-
-    private String extractAccessToken(String response) {
         try {
-            JsonNode jsonNode = objectMapper.readTree(response);
-            return jsonNode.get(OAuthConstants.ACCESS_TOKEN).asText();
+            return webClient.get()
+                    .uri(oAuthProperties.getProvider().getNaver().getUserInfoUri())
+                    .header(HttpHeaders.AUTHORIZATION, SecurityConstants.BEARER_PREFIX + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, res -> {
+                        log.warn("[OAuth] 네이버 사용자 정보 요청 실패 (4xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_USER_INFO_REQUEST_FAILED));
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, res -> {
+                        log.error("[OAuth] 네이버 사용자 정보 요청 서버 오류 (5xx): {}", res.statusCode());
+                        return Mono.error(new HandledException(ErrorCode.OAUTH_PROVIDER_SERVER_ERROR));
+                    })
+                    .bodyToMono(NaverUserInfoResponse.class) // 응답 Body 객체 매핑: JSON -> NaverUserInfoResponse 클래스 인스턴스로 역직렬화
+                    .block();
+        } catch (WebClientRequestException e) {
+            log.error("[OAuth] 네이버 사용자 정보 요청 WebClient 실패", e);
+            throw new HandledException(ErrorCode.OAUTH_PROVIDER_UNREACHABLE);
         } catch (Exception e) {
-            throw new HandledException(ErrorCode.FAILED_TO_PARSE_OAUTH_TOKEN);
+            log.error("[OAuth] 네이버 사용자 정보 요청 중 알 수 없는 오류", e);
+            throw new HandledException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/org/example/tablenow/domain/auth/service/TokenService.java
+++ b/src/main/java/org/example/tablenow/domain/auth/service/TokenService.java
@@ -9,6 +9,8 @@ import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
 import org.example.tablenow.global.security.enums.BlacklistReason;
 import org.example.tablenow.global.util.JwtUtil;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -36,50 +38,69 @@ public class TokenService {
         String refreshToken = UUID.randomUUID().toString();
         String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
 
-        // userId를 값으로 Redis에 저장
-        redisTemplate.opsForValue().set(
-                redisKey,
-                String.valueOf(user.getId()),
-                SecurityConstants.REFRESH_TOKEN_TTL_SECONDS,
-                TimeUnit.SECONDS
-        );
+        try {
+            // userId를 값으로 Redis에 저장
+            redisTemplate.opsForValue().set(
+                    redisKey,
+                    String.valueOf(user.getId()),
+                    SecurityConstants.REFRESH_TOKEN_TTL_SECONDS,
+                    TimeUnit.SECONDS
+            );
+        } catch (RedisConnectionFailureException | RedisSystemException e) {
+            log.warn("[Redis] RefreshToken Redis 저장 실패: {}", e.getMessage());
+            throw new HandledException(ErrorCode.REDIS_CONNECTION_ERROR);
+        }
 
         return refreshToken;
     }
 
     public RefreshToken validateRefreshToken(String refreshToken, Long userId) {
         String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
-        String userIdValue = redisTemplate.opsForValue().get(redisKey);
 
-        if (userIdValue == null) {
-            throw new HandledException(ErrorCode.EXPIRED_REFRESH_TOKEN);
-        }
-        if (!userIdValue.equals(String.valueOf(userId))) {
-            throw new HandledException(ErrorCode.INVALID_REFRESH_TOKEN_OWNER);
-        }
+        try {
+            String userIdValue = redisTemplate.opsForValue().get(redisKey);
 
-        return RefreshToken.builder()
-                .token(refreshToken)
-                .userId(Long.valueOf(userIdValue))
-                .build();
+            if (userIdValue == null) {
+                throw new HandledException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+            }
+            if (!userIdValue.equals(String.valueOf(userId))) {
+                throw new HandledException(ErrorCode.INVALID_REFRESH_TOKEN_OWNER);
+            }
+
+            return RefreshToken.builder()
+                    .token(refreshToken)
+                    .userId(Long.valueOf(userIdValue))
+                    .build();
+        } catch (RedisConnectionFailureException | RedisSystemException e) {
+            log.error("[Redis] RefreshToken 검증 중 Redis 오류 발생", e);
+            throw new HandledException(ErrorCode.REDIS_CONNECTION_ERROR);
+        }
     }
 
     public void deleteRefreshToken(String refreshToken) {
         String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
-        Boolean deleted = redisTemplate.delete(redisKey);
 
-        if (!deleted) {
-            log.warn("삭제 시도한 RefreshToken이 Redis에 존재하지 않아 삭제되지 않음. 토큰값: {}", refreshToken);
+        try {
+            Boolean deleted = redisTemplate.delete(redisKey);
+            if (!deleted) {
+                log.warn("[Redis] 삭제 시도한 RefreshToken이 Redis에 존재하지 않아 삭제되지 않음. 토큰값: {}", refreshToken);
+            }
+        } catch (RedisConnectionFailureException | RedisSystemException e) {
+            log.warn("[Redis] RefreshToken 삭제 중 Redis 오류 발생: {}", e.getMessage());
         }
     }
 
     public void addToBlacklist(String accessToken, Long userId, BlacklistReason reason) {
-        String jwt = jwtUtil.substringToken(accessToken);
-        String redisKey = SecurityConstants.BLACKLIST_TOKEN_KEY_PREFIX + jwt;
-        long ttl = jwtUtil.getRemainingTokenTime(jwt);
-        String value = String.format("%s:userId=%d", reason.getValue(), userId);
+        try {
+            String jwt = jwtUtil.substringToken(accessToken);
+            String redisKey = SecurityConstants.BLACKLIST_TOKEN_KEY_PREFIX + jwt;
+            long ttl = jwtUtil.getRemainingTokenTime(jwt);
+            String value = String.format("%s:userId=%d", reason.getValue(), userId);
 
-        redisTemplate.opsForValue().set(redisKey, value, ttl, TimeUnit.SECONDS);
-        log.info("AccessToken 블랙리스트 등록 완료: {} (TTL {}초)", jwt, ttl);
+            redisTemplate.opsForValue().set(redisKey, value, ttl, TimeUnit.SECONDS);
+            log.info("[Redis] AccessToken 블랙리스트 등록 완료: {} (TTL {}초)", jwt, ttl);
+        } catch (RedisConnectionFailureException | RedisSystemException e) {
+            log.warn("[Redis] AccessToken 블랙리스트 등록 실패: {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/user/service/UserService.java
+++ b/src/main/java/org/example/tablenow/domain/user/service/UserService.java
@@ -56,12 +56,12 @@ public class UserService {
             if (user.getOauthProvider() == OAuthProvider.KAKAO) {
                 kakaoAuthService.unlinkKakaoByAdminKey(user.getOauthId());
             } else if (user.getOauthProvider() == OAuthProvider.NAVER) {
-                log.info("네이버는 OAuth AccessToken이 없으므로 연결 해제를 생략.");
+                log.info("[OAuth] 네이버는 OAuth AccessToken이 없으므로 연결 해제를 생략.");
             }
         } else {
             // 일반 유저 비밀번호 검증
             if (!StringUtils.hasText(request.getPassword())) {
-                throw new HandledException(ErrorCode.MISSING_PASSWORD);
+                throw new HandledException(ErrorCode.PASSWORD_REQUIRED);
             }
             validatePassword(user, request.getPassword());
         }
@@ -90,10 +90,10 @@ public class UserService {
 
         // Dto 검증
         if (!StringUtils.hasText(request.getPassword()) || !StringUtils.hasText(request.getNewPassword())) {
-            throw new HandledException(ErrorCode.MISSING_PASSWORD);
+            throw new HandledException(ErrorCode.PASSWORD_REQUIRED);
         }
         if (!Pattern.matches(RegexConstants.PASSWORD_REGEX, request.getNewPassword())) {
-            throw new HandledException(ErrorCode.INVALID_PASSWORD_FORMAT);
+            throw new HandledException(ErrorCode.PASSWORD_FORMAT_INVALID);
         }
 
         validatePassword(user, request.getPassword());

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -12,19 +12,26 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
 
-    // AUTH & USER
+    // AUTH
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN_OWNER(HttpStatus.UNAUTHORIZED, "RefreshToken의 소유자가 일치하지 않습니다."),
+    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 권한입니다."),
+    OAUTH_PROVIDER_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "OAuth 제공자의 서버에서 오류가 발생했습니다."),
+    OAUTH_PROVIDER_UNREACHABLE(HttpStatus.SERVICE_UNAVAILABLE, "OAuth 제공자 서버에 연결할 수 없습니다."),
+    OAUTH_RESPONSE_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 토큰 파싱에 실패했습니다."),
+    OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "OAuth 토큰 요청에 실패했습니다."),
+    OAUTH_USER_INFO_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 사용자 정보 요청에 실패했습니다."),
+    OAUTH_USER_UNLINK_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "OAuth 사용자 연결 해제 요청에 실패했습니다."),
+    REFRESH_TOKEN_MISSING(HttpStatus.BAD_REQUEST, "요청 쿠키에 리프레시 토큰이 존재하지 않습니다."),
+    UNSUPPORTED_SOCIAL_USER_OPERATION(HttpStatus.FORBIDDEN, "소셜 로그인 유저는 해당 기능을 사용할 수 없습니다."),
+
+    // USER
     ALREADY_DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일 입니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
-    FAILED_TO_PARSE_OAUTH_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 토큰 파싱에 실패했습니다."),
-    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 권한입니다."),
-    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다."),
-    INVALID_REFRESH_TOKEN_OWNER(HttpStatus.UNAUTHORIZED, "RefreshToken의 소유자가 일치하지 않습니다."),
-    MISSING_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 필수 입력값입니다."),
-    REFRESH_TOKEN_MISSING(HttpStatus.BAD_REQUEST, "요청 쿠키에 리프레시 토큰이 존재하지 않습니다."),
+    PASSWORD_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다."),
+    PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "비밀번호는 필수 입력값입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
-    UNSUPPORTED_SOCIAL_USER_OPERATION(HttpStatus.FORBIDDEN, "소셜 로그인 유저는 해당 기능을 사용할 수 없습니다."),
 
     // CATEGORY
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 카테고리를 찾을 수 없습니다."),
@@ -80,6 +87,7 @@ public enum ErrorCode {
     INVALID_IMAGE_DOMAIN(HttpStatus.BAD_REQUEST, "잘못된 이미지 도메인입니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL 입니다."),
+    S3_PRESIGNED_URL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Presigned URL 생성 중 오류가 발생했습니다."),
 
     // COMMON
     INVALID_SORT_FIELD(HttpStatus.BAD_REQUEST, "정렬 필드가 잘못되었습니다."),
@@ -94,7 +102,10 @@ public enum ErrorCode {
     TOSS_PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "Tosspayment에서 결제 취소가 실패했습니다."),
     PAYMENT_RESERVATION_MISMATCH(HttpStatus.BAD_REQUEST, "예약이 결제와 일치하지 않습니다."),
     ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 결제가 취소된 예약입니다."),
-    UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.UNAUTHORIZED, "본인 예약이 아닙니다.");
+    UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.UNAUTHORIZED, "본인 예약이 아닙니다."),
+
+    // REDIS
+    REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 연결 중 오류가 발생했습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/org/example/tablenow/global/util/OAuthResponseParser.java
+++ b/src/main/java/org/example/tablenow/global/util/OAuthResponseParser.java
@@ -2,15 +2,19 @@ package org.example.tablenow.global.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.example.tablenow.global.constant.OAuthConstants;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class OAuthResponseParser {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
-    public static String extractAccessToken(String response) {
+    public String extractAccessToken(String response) {
         try {
             JsonNode jsonNode = objectMapper.readTree(response);
             return jsonNode.get(OAuthConstants.ACCESS_TOKEN).asText();

--- a/src/main/java/org/example/tablenow/global/util/OAuthResponseParser.java
+++ b/src/main/java/org/example/tablenow/global/util/OAuthResponseParser.java
@@ -1,0 +1,21 @@
+package org.example.tablenow.global.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.tablenow.global.constant.OAuthConstants;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+
+public class OAuthResponseParser {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String extractAccessToken(String response) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response);
+            return jsonNode.get(OAuthConstants.ACCESS_TOKEN).asText();
+        } catch (Exception e) {
+            throw new HandledException(ErrorCode.OAUTH_RESPONSE_PARSING_FAILED);
+        }
+    }
+}

--- a/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
@@ -155,39 +155,41 @@ class AuthServiceTest {
 
         private String oldRefreshToken;
         private String oldAccessToken;
+        private User savedUser;
 
         @BeforeEach
         void setupTokens() {
             SignupResponse response = authService.signup(signupRequest);
-            User savedUser = userService.getUser(response.getId());
+            savedUser = userService.getUser(response.getId());
             oldRefreshToken = tokenService.createRefreshToken(savedUser);
             oldAccessToken = tokenService.createAccessToken(savedUser);
         }
 
-//        @Test
-//        void 토큰_재발급_성공() {
-//            // when
-//            TokenResponse tokenResponse = authService.refreshToken(oldRefreshToken);
-//            String newAccessToken = tokenResponse.getAccessToken();
-//            String newRefreshToken = tokenResponse.getRefreshToken();
-//
-//            // then
-//            assertAll(
-//                    () -> assertThat(newAccessToken).isNotNull(),
-//                    () -> assertThat(newRefreshToken).isNotNull(),
-//                    () -> assertThat(newAccessToken).isNotEqualTo(oldAccessToken),
-//                    () -> assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken)
-//            );
-//            // 기존 RefreshToken이 삭제되었는지 확인
-//            assertThatThrownBy(() -> tokenService.validateRefreshToken(oldRefreshToken))
-//                    .isInstanceOf(HandledException.class)
-//                    .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDefaultMessage());
-//        }
+        @Test
+        void 토큰_재발급_성공() {
+            // when
+            TokenResponse tokenResponse = authService.refreshToken(oldRefreshToken, oldAccessToken, savedUser.getId());
+            String newAccessToken = tokenResponse.getAccessToken();
+            String newRefreshToken = tokenResponse.getRefreshToken();
+
+            // then
+            assertAll(
+                    () -> assertThat(newAccessToken).isNotNull(),
+                    () -> assertThat(newRefreshToken).isNotNull(),
+                    () -> assertThat(newAccessToken).isNotEqualTo(oldAccessToken),
+                    () -> assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken)
+            );
+            // 기존 RefreshToken이 삭제되었는지 확인
+            assertThatThrownBy(() -> tokenService.validateRefreshToken(oldRefreshToken, savedUser.getId()))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDefaultMessage());
+        }
     }
 
     @Nested
     class 로그아웃 {
 
+        private String accessToken;
         private String refreshToken;
         private User savedUser;
 
@@ -204,18 +206,19 @@ class AuthServiceTest {
 
             SignupResponse response = authService.signup(request);
             savedUser = userService.getUser(response.getId());
+            accessToken = tokenService.createAccessToken(savedUser);
             refreshToken = tokenService.createRefreshToken(savedUser);
         }
 
-//        @Test
-//        void 로그아웃_시_리프레시토큰_Redis에서_삭제_성공() {
-//            // when
-//            authService.logout(refreshToken);
-//
-//            // then: RefreshToken이 삭제되었는지 확인
-//            assertThatThrownBy(() -> tokenService.validateRefreshToken(refreshToken))
-//                    .isInstanceOf(HandledException.class)
-//                    .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDefaultMessage());
-//        }
+        @Test
+        void 로그아웃_시_리프레시토큰_Redis에서_삭제_성공() {
+            // when
+            authService.logout(refreshToken, accessToken, savedUser.getId());
+
+            // then: RefreshToken이 삭제되었는지 확인
+            assertThatThrownBy(() -> tokenService.validateRefreshToken(refreshToken, savedUser.getId()))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDefaultMessage());
+        }
     }
 }

--- a/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
@@ -61,7 +61,7 @@ class AuthServiceTest {
     class 회원가입 {
 
         @Test
-        void 중복된_이메일로_가입_시_예외() {
+        void 중복된_이메일로_가입_시_예외처리() {
             // given
             authService.signup(signupRequest);
 
@@ -98,7 +98,7 @@ class AuthServiceTest {
         }
 
         @Test
-        void 존재하지_않는_이메일로_로그인_시_예외() {
+        void 존재하지_않는_이메일로_로그인_시_예외처리() {
             // given
             SigninRequest invalidRequest = SigninRequest.builder()
                     .email("invalid@test.com")
@@ -112,7 +112,7 @@ class AuthServiceTest {
         }
 
         @Test
-        void 탈퇴한_사용자가_로그인_시도_시_예외() {
+        void 탈퇴한_사용자가_로그인_시도_시_예외처리() {
             // given
             User savedUser = userService.getUser(signupResponse.getId());
             savedUser.deleteUser();
@@ -124,7 +124,7 @@ class AuthServiceTest {
         }
 
         @Test
-        void 비밀번호가_저장된_비밀번호와_일치하지_않을_시_예외() {
+        void 비밀번호가_저장된_비밀번호와_일치하지_않을_시_예외처리() {
             // given
             SigninRequest wrongPasswordRequest = SigninRequest.builder()
                     .email("user@test.com")

--- a/src/test/java/org/example/tablenow/domain/auth/service/KakaoAuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/KakaoAuthServiceTest.java
@@ -160,7 +160,7 @@ class KakaoAuthServiceTest {
         }
 
         @Test
-        void 액세스토큰_JSON파싱_실패_예외처리() throws Exception {
+        void 액세스토큰_JSON파싱_실패_예외처리() {
             // given
             String invalidAccessTokenJson = "invalid json";
             mockWebClientTokenRequest(Mono.just(invalidAccessTokenJson));
@@ -174,7 +174,7 @@ class KakaoAuthServiceTest {
         }
 
         @Test
-        void 탈퇴한_유저가_로그인_시_예외처리() throws Exception {
+        void 탈퇴한_유저가_로그인_시_예외처리() {
             // given
             String accessTokenJson = createAccessTokenJson(KAKAO_ACCESS_TOKEN);
             KakaoUserInfoResponse response = createKakaoUserInfoResponse(

--- a/src/test/java/org/example/tablenow/domain/auth/service/KakaoAuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/KakaoAuthServiceTest.java
@@ -1,6 +1,5 @@
 package org.example.tablenow.domain.auth.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.tablenow.domain.auth.dto.response.TokenResponse;
 import org.example.tablenow.domain.auth.oAuth.config.KakaoOAuthProperties;
 import org.example.tablenow.domain.auth.oAuth.config.OAuthProperties;
@@ -12,6 +11,7 @@ import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.domain.user.repository.UserRepository;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.example.tablenow.global.util.OAuthResponseParser;
 import org.example.tablenow.global.util.PhoneNumberNormalizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -20,15 +20,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
+import java.net.URI;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.example.tablenow.testutil.OAuthTestUtil.createAccessTokenJson;
-import static org.example.tablenow.testutil.OAuthTestUtil.stubJsonParsing;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -47,11 +52,11 @@ class KakaoAuthServiceTest {
     @Mock
     private WebClient webClient;
     @Mock
-    private ObjectMapper objectMapper;
-    @Mock
     private OAuthProperties oAuthProperties;
     @Mock
     private KakaoOAuthProperties kakaoOAuthProperties;
+    @Mock
+    private OAuthResponseParser oAuthResponseParser;
 
     // WebClient mocking을 위한 내부 변수들
     @Mock
@@ -99,25 +104,37 @@ class KakaoAuthServiceTest {
                 .build();
     }
 
-    private void mockWebClientTokenRequest(String responseJson) {
+    // access_token 요청하는 WebClient mocking
+    private void mockWebClientTokenRequest(Mono<String> response) {
         when(webClient.post()).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.contentType(any())).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.body(any(BodyInserter.class))).thenReturn(requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.bodyToMono(String.class)).thenReturn(Mono.just(responseJson));
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(String.class)).thenReturn(response);
     }
 
-    // 발급받은 access_token으로 Kakao 사용자 정보 요청하는 WebClient mocking
-    private void mockWebClientUserInfoRequest(KakaoUserInfoResponse response) {
+    // Kakao 사용자 정보 요청하는 WebClient mocking
+    private void mockWebClientUserInfoRequest(Mono<KakaoUserInfoResponse> response) {
         when(webClient.get()).thenAnswer(invocation -> requestHeadersUriSpec);
-        when(requestHeadersUriSpec.uri(anyString()))
-                .thenAnswer(invocation -> requestHeadersSpec);
-        when(requestHeadersSpec.header(anyString(), anyString()))
-                .thenAnswer(invocation -> requestHeadersSpec);
+        when(requestHeadersUriSpec.uri(anyString())).thenAnswer(invocation -> requestHeadersSpec);
+        when(requestHeadersSpec.header(anyString(), anyString())).thenAnswer(invocation -> requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.bodyToMono(KakaoUserInfoResponse.class))
-                .thenReturn(Mono.just(response));
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(KakaoUserInfoResponse.class)).thenReturn(response);
+    }
+
+    // Kakao 사용자 연결 해제 요청하는 WebClient mocking
+    private void mockWebClientUnlinkRequest(Mono<Void> response) {
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.header(anyString(), anyString())).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.contentType(any())).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.body(any(BodyInserter.class))).thenReturn(requestHeadersSpec);
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+        when(responseSpec.bodyToMono(Void.class)).thenReturn(response);
     }
 
     @Nested
@@ -143,11 +160,11 @@ class KakaoAuthServiceTest {
         }
 
         @Test
-        void 액세스토큰_JSON파싱_실패_예외_발생() throws Exception {
+        void 액세스토큰_JSON파싱_실패_예외처리() throws Exception {
             // given
             String invalidAccessTokenJson = "invalid json";
-            mockWebClientTokenRequest(invalidAccessTokenJson);
-            when(objectMapper.readTree(invalidAccessTokenJson))
+            mockWebClientTokenRequest(Mono.just(invalidAccessTokenJson));
+            when(oAuthResponseParser.extractAccessToken(invalidAccessTokenJson))
                     .thenThrow(new RuntimeException("JSON 파싱 실패"));
 
             // when & then
@@ -157,7 +174,7 @@ class KakaoAuthServiceTest {
         }
 
         @Test
-        void 탈퇴한_유저가_로그인_시_예외_발생() throws Exception {
+        void 탈퇴한_유저가_로그인_시_예외처리() throws Exception {
             // given
             String accessTokenJson = createAccessTokenJson(KAKAO_ACCESS_TOKEN);
             KakaoUserInfoResponse response = createKakaoUserInfoResponse(
@@ -167,9 +184,11 @@ class KakaoAuthServiceTest {
                     .build();
             deletedUser.deleteUser();
 
-            mockWebClientTokenRequest(accessTokenJson);
-            mockWebClientUserInfoRequest(response);
-            stubJsonParsing(objectMapper, accessTokenJson);
+            mockWebClientTokenRequest(Mono.just(accessTokenJson));
+            when(oAuthResponseParser.extractAccessToken(accessTokenJson))
+                    .thenReturn(KAKAO_ACCESS_TOKEN);
+
+            mockWebClientUserInfoRequest(Mono.just(response));
 
             when(userRepository.findByEmail("deleted@test.com")).thenReturn(Optional.of(deletedUser));
 
@@ -181,7 +200,49 @@ class KakaoAuthServiceTest {
         }
 
         @Test
-        void 기존유저_성공() throws Exception {
+        void 카카오_토큰요청_중_WebClient_요청실패_예외처리() {
+            // given
+            WebClientRequestException webClientRequestException = new WebClientRequestException(
+                    new IOException("연결 실패"),
+                    HttpMethod.POST,
+                    URI.create("https://kauth.kakao.com/oauth/token"),
+                    HttpHeaders.EMPTY
+            );
+            mockWebClientTokenRequest(Mono.error(webClientRequestException));
+
+            // when & then
+            assertThatThrownBy(() -> kakaoAuthService.login(AUTHORIZATION_CODE))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.OAUTH_PROVIDER_UNREACHABLE.getDefaultMessage());
+        }
+
+        @Test
+        void 카카오_유저정보요청_중_WebClient_요청실패_예외처리() {
+            // given
+            String accessTokenJson = createAccessTokenJson(KAKAO_ACCESS_TOKEN);
+
+            // 1. access token 요청 mocking (정상 흐름)
+            mockWebClientTokenRequest(Mono.just(accessTokenJson));
+            when(oAuthResponseParser.extractAccessToken(accessTokenJson))
+                    .thenReturn(KAKAO_ACCESS_TOKEN);
+
+            // 2. 유저정보 요청 mocking (이 부분에서 예외 발생)
+            WebClientRequestException webClientRequestException = new WebClientRequestException(
+                    new IOException("연결 실패"),
+                    HttpMethod.GET,
+                    URI.create("https://kapi.kakao.com/v2/user/me"),
+                    HttpHeaders.EMPTY
+            );
+            mockWebClientUserInfoRequest(Mono.error(webClientRequestException));
+
+            // when & then
+            assertThatThrownBy(() -> kakaoAuthService.login(AUTHORIZATION_CODE))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.OAUTH_PROVIDER_UNREACHABLE.getDefaultMessage());
+        }
+
+        @Test
+        void 기존유저_성공() {
             // given
             String accessTokenJson = createAccessTokenJson(KAKAO_ACCESS_TOKEN); // 카카오 서버에서 받은 토큰 응답 가정
             KakaoUserInfoResponse response = createKakaoUserInfoResponse(
@@ -190,9 +251,11 @@ class KakaoAuthServiceTest {
                     .email("user@test.com")
                     .build();
 
-            mockWebClientTokenRequest(accessTokenJson);
-            mockWebClientUserInfoRequest(response);
-            stubJsonParsing(objectMapper, accessTokenJson);
+            mockWebClientTokenRequest(Mono.just(accessTokenJson));
+            when(oAuthResponseParser.extractAccessToken(accessTokenJson))
+                    .thenReturn(KAKAO_ACCESS_TOKEN);
+
+            mockWebClientUserInfoRequest(Mono.just(response));
 
             when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
             when(tokenService.createAccessToken(user)).thenReturn("access_token");
@@ -207,7 +270,7 @@ class KakaoAuthServiceTest {
         }
 
         @Test
-        void 신규회원가입_성공() throws Exception {
+        void 신규회원가입_성공() {
             // given
             String accessTokenJson = createAccessTokenJson(KAKAO_ACCESS_TOKEN);
             KakaoUserInfoResponse response = createKakaoUserInfoResponse(
@@ -216,9 +279,11 @@ class KakaoAuthServiceTest {
             KakaoUserInfo kakaoUserInfo = KakaoUserInfo.fromKakaoUserInfoResponse(response);
             User newUser = createUserFromKakao(kakaoUserInfo);
 
-            mockWebClientTokenRequest(accessTokenJson);
-            mockWebClientUserInfoRequest(response);
-            stubJsonParsing(objectMapper, accessTokenJson);
+            mockWebClientTokenRequest(Mono.just(accessTokenJson));
+            when(oAuthResponseParser.extractAccessToken(accessTokenJson))
+                    .thenReturn(KAKAO_ACCESS_TOKEN);
+
+            mockWebClientUserInfoRequest(Mono.just(response));
 
             when(userRepository.findByEmail("newuser@test.com")).thenReturn(Optional.empty());
             when(userRepository.save(any(User.class))).thenReturn(newUser);
@@ -247,15 +312,26 @@ class KakaoAuthServiceTest {
         }
 
         @Test
+        void 카카오_연결해제_중_WebClient_요청실패_예외처리() {
+            // given
+            WebClientRequestException webClientRequestException = new WebClientRequestException(
+                    new IOException("연결 실패"),
+                    HttpMethod.POST,
+                    URI.create("https://kapi.kakao.com/v1/user/unlink"),
+                    HttpHeaders.EMPTY
+            );
+            mockWebClientUnlinkRequest(Mono.error(webClientRequestException));
+
+            // when & then
+            assertThatThrownBy(() -> kakaoAuthService.unlinkKakaoByAdminKey(kakaoId))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.OAUTH_PROVIDER_UNREACHABLE.getDefaultMessage());
+        }
+
+        @Test
         void unlinkKakaoByAdminKey_성공() {
-            // given: mock WebClient 호출
-            when(webClient.post()).thenReturn(requestBodyUriSpec);
-            when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodyUriSpec);
-            when(requestBodyUriSpec.header(anyString(), anyString())).thenReturn(requestBodyUriSpec);
-            when(requestBodyUriSpec.contentType(any())).thenReturn(requestBodyUriSpec);
-            when(requestBodyUriSpec.body(any(BodyInserter.class))).thenReturn(requestHeadersSpec);
-            when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-            when(responseSpec.bodyToMono(Void.class)).thenReturn(Mono.empty());
+            // given
+            mockWebClientUnlinkRequest(Mono.empty());
 
             // when & then
             assertDoesNotThrow(() -> kakaoAuthService.unlinkKakaoByAdminKey(kakaoId));

--- a/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
@@ -1,7 +1,11 @@
 package org.example.tablenow.domain.auth.service;
 
+import org.example.tablenow.domain.auth.dto.token.RefreshToken;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
+import org.example.tablenow.global.constant.SecurityConstants;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
 import org.example.tablenow.global.util.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -10,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -17,8 +23,11 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
@@ -37,7 +46,6 @@ class TokenServiceTest {
     @Mock
     private ValueOperations<String, String> ops;
 
-    private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
     private static final Long USER_ID = 1L;
 
     @BeforeEach
@@ -87,13 +95,26 @@ class TokenServiceTest {
                 .build();
 
         @Test
+        void Redis_장애_발생시_RefreshToken_저장_실패_예외() {
+            // given
+            willThrow(new RedisConnectionFailureException("Redis 연결 중 오류 발생"))
+                    .given(ops)
+                    .set(startsWith(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
+
+            // when & then
+            assertThatThrownBy(() -> tokenService.createRefreshToken(user))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.REDIS_CONNECTION_ERROR.getDefaultMessage());
+        }
+
+        @Test
         void 사용자ID로_리프레시_토큰을_생성하고_Redis에_저장_성공() {
             // when
             String refreshToken = tokenService.createRefreshToken(user);
 
             // then
             verify(redisTemplate.opsForValue())
-                    .set(startsWith(REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
+                    .set(startsWith(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
             assertThat(refreshToken).isNotNull();
         }
     }
@@ -102,34 +123,60 @@ class TokenServiceTest {
     @Nested
     class 리프레시_토큰_검증 {
 
-//        @Test
-//        void Redis에_존재하지_않는_토큰으로_검증_시_예외_발생() {
-//            // given
-//            String token = "invalid";
-//            given(ops.get(REFRESH_TOKEN_KEY_PREFIX + token)).willReturn(null);
-//
-//            // when & then
-//            assertThatThrownBy(() -> tokenService.validateRefreshToken(token))
-//                    .isInstanceOf(HandledException.class)
-//                    .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDefaultMessage());
-//        }
+        @Test
+        void Redis에_존재하지_않는_토큰으로_검증_시_예외() {
+            // given
+            String token = "invalid";
+            given(ops.get(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token)).willReturn(null);
 
-//        @Test
-//        void Redis에_저장된_토큰으로_검증_시_RefreshToken_반환_성공() {
-//            // given
-//            String token = UUID.randomUUID().toString();
-//            String redisKey = REFRESH_TOKEN_KEY_PREFIX + token;
-//            given(ops.get(redisKey)).willReturn(USER_ID.toString());
-//
-//            // when
-//            RefreshToken result = tokenService.validateRefreshToken(token);
-//
-//            // then
-//            assertAll(
-//                    () -> assertThat(result.getUserId()).isEqualTo(USER_ID),
-//                    () -> assertThat(result.getToken()).isEqualTo(token)
-//            );
-//        }
+            // when & then
+            assertThatThrownBy(() -> tokenService.validateRefreshToken(token, USER_ID))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.EXPIRED_REFRESH_TOKEN.getDefaultMessage());
+        }
+
+        @Test
+        void Redis에_저장된_userId와_다른_사용자가_요청시_예외() {
+            // given
+            String token = UUID.randomUUID().toString();
+            String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
+            given(ops.get(redisKey)).willReturn("999");
+
+            // when & then
+            assertThatThrownBy(() -> tokenService.validateRefreshToken(token, USER_ID))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.INVALID_REFRESH_TOKEN_OWNER.getDefaultMessage());
+        }
+
+        @Test
+        void Redis_장애_발생시_RefreshToken_검증_실패_예외() {
+            // given
+            String token = UUID.randomUUID().toString();
+            given(ops.get(anyString()))
+                    .willThrow(new RedisSystemException("Redis 연결 중 오류 발생", new RuntimeException()));
+
+            // when & then
+            assertThatThrownBy(() -> tokenService.validateRefreshToken(token, USER_ID))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessage(ErrorCode.REDIS_CONNECTION_ERROR.getDefaultMessage());
+        }
+
+        @Test
+        void Redis에_저장된_토큰으로_검증_시_RefreshToken_반환_성공() {
+            // given
+            String token = UUID.randomUUID().toString();
+            String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
+            given(ops.get(redisKey)).willReturn(USER_ID.toString());
+
+            // when
+            RefreshToken result = tokenService.validateRefreshToken(token, USER_ID);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.getUserId()).isEqualTo(USER_ID),
+                    () -> assertThat(result.getToken()).isEqualTo(token)
+            );
+        }
     }
 
     @Nested
@@ -139,7 +186,7 @@ class TokenServiceTest {
         void Redis에서_리프레시_토큰_삭제_성공() {
             // given
             String token = UUID.randomUUID().toString();
-            String redisKey = REFRESH_TOKEN_KEY_PREFIX + token;
+            String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
 
             // when
             tokenService.deleteRefreshToken(token);

--- a/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
@@ -95,7 +95,7 @@ class TokenServiceTest {
                 .build();
 
         @Test
-        void Redis_장애_발생시_RefreshToken_저장_실패_예외() {
+        void Redis_장애_발생시_RefreshToken_저장_실패_예외처리() {
             // given
             willThrow(new RedisConnectionFailureException("Redis 연결 중 오류 발생"))
                     .given(ops)
@@ -124,7 +124,7 @@ class TokenServiceTest {
     class 리프레시_토큰_검증 {
 
         @Test
-        void Redis에_존재하지_않는_토큰으로_검증_시_예외() {
+        void Redis에_존재하지_않는_토큰으로_검증_시_예외처리() {
             // given
             String token = "invalid";
             given(ops.get(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token)).willReturn(null);
@@ -136,7 +136,7 @@ class TokenServiceTest {
         }
 
         @Test
-        void Redis에_저장된_userId와_다른_사용자가_요청시_예외() {
+        void Redis에_저장된_userId와_다른_사용자가_요청시_예외처리() {
             // given
             String token = UUID.randomUUID().toString();
             String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
@@ -149,7 +149,7 @@ class TokenServiceTest {
         }
 
         @Test
-        void Redis_장애_발생시_RefreshToken_검증_실패_예외() {
+        void Redis_장애_발생시_RefreshToken_검증_실패_예외처리() {
             // given
             String token = UUID.randomUUID().toString();
             given(ops.get(anyString()))

--- a/src/test/java/org/example/tablenow/domain/user/service/UserServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/user/service/UserServiceTest.java
@@ -2,8 +2,12 @@ package org.example.tablenow.domain.user.service;
 
 import org.example.tablenow.domain.auth.oAuth.config.OAuthProvider;
 import org.example.tablenow.domain.auth.service.KakaoAuthService;
+import org.example.tablenow.domain.auth.service.TokenService;
 import org.example.tablenow.domain.image.service.ImageService;
+import org.example.tablenow.domain.user.dto.request.UpdatePasswordRequest;
 import org.example.tablenow.domain.user.dto.request.UpdateProfileRequest;
+import org.example.tablenow.domain.user.dto.request.UserDeleteRequest;
+import org.example.tablenow.domain.user.dto.response.SimpleUserResponse;
 import org.example.tablenow.domain.user.dto.response.UserProfileResponse;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
@@ -11,6 +15,7 @@ import org.example.tablenow.domain.user.repository.UserRepository;
 import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.example.tablenow.global.security.enums.BlacklistReason;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,12 +44,17 @@ class UserServiceTest {
     private ImageService imageService;
     @Mock
     private KakaoAuthService kakaoAuthService;
+    @Mock
+    private TokenService tokenService;
 
     @InjectMocks
     private UserService userService;
 
-    Long userId = 1L;
-    AuthUser authUser = new AuthUser(userId, "user@test.com", UserRole.ROLE_USER, "일반회원");
+    private static final Long USER_ID = 1L;
+    private static final String REFRESH_TOKEN = "test-refresh-token";
+    private static final String ACCESS_TOKEN = "test-access-token";
+
+    AuthUser authUser = new AuthUser(USER_ID, "user@test.com", UserRole.ROLE_USER, "일반회원");
     User user;
 
     @BeforeEach
@@ -62,7 +72,7 @@ class UserServiceTest {
 
     private User createSocialUser(OAuthProvider provider, String oauthId) {
         return User.builder()
-                .id(userId)
+                .id(USER_ID)
                 .email("socialuser@test.com")
                 .nickname("소셜회원")
                 .userRole(UserRole.ROLE_USER)
@@ -78,20 +88,20 @@ class UserServiceTest {
     class 유저_ID_조회 {
 
         @Test
-        void 존재하지_않는_ID면_예외_발생() {
+        void 존재하지_않는_ID면_예외처리() {
             // given
-            given(userRepository.findById(userId)).willReturn(Optional.empty());
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
             // when & then
             HandledException ex = assertThrows(HandledException.class, () ->
-                    userService.getUser(userId));
+                    userService.getUser(USER_ID));
             assertEquals(ErrorCode.USER_NOT_FOUND.getDefaultMessage(), ex.getMessage());
         }
 
         @Test
         void 유저_반환_성공() {
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            assertEquals(user, userService.getUser(userId));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            assertEquals(user, userService.getUser(USER_ID));
         }
     }
 
@@ -99,7 +109,7 @@ class UserServiceTest {
     class 유저_이메일_조회 {
 
         @Test
-        void 존재하지_않는_이메일이면_예외_발생() {
+        void 존재하지_않는_이메일이면_예외처리() {
             // given
             given(userRepository.findByEmail(authUser.getEmail())).willReturn(Optional.empty());
 
@@ -119,204 +129,215 @@ class UserServiceTest {
     @Nested
     class 회원_탈퇴 {
 
-//        @Test
-//        void 비밀번호가_없으면_예외_발생() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//
-//            UserDeleteRequest request = UserDeleteRequest.builder()
-//                    .password(null)
-//                    .build();
-//
-//            // when & then
-//            HandledException exception = assertThrows(HandledException.class, () ->
-//                    userService.deleteUser(authUser, request)
-//            );
-//            assertEquals(ErrorCode.MISSING_PASSWORD.getDefaultMessage(), exception.getMessage());
-//        }
-//
-//        @Test
-//        void 비밀번호_일치하지_않으면_예외_발생() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
-//
-//            UserDeleteRequest request = UserDeleteRequest.builder()
-//                    .password("wrong-password")
-//                    .build();
-//
-//            // when & then
-//            HandledException exception = assertThrows(HandledException.class, () ->
-//                    userService.deleteUser(authUser, request)
-//            );
-//            assertEquals(ErrorCode.INCORRECT_PASSWORD.getDefaultMessage(), exception.getMessage());
-//        }
-//
-//        @Test
-//        void 탈퇴_성공_이미지있는_유저는_이미지_삭제() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-//
-//            UserDeleteRequest request = UserDeleteRequest.builder()
-//                    .password("encoded-password")
-//                    .build();
-//
-//            // when
-//            SimpleUserResponse response = userService.deleteUser(authUser, request);
-//
-//            // then
-//            assertEquals(userId, response.getId());
-//            verify(imageService).delete("image-url");
-//        }
-//
-//        @Test
-//        void 탈퇴_성공_이미지없는_유저는_이미지_삭제_안함() {
-//            // given
-//            user.updateImageUrl(null);
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-//
-//            UserDeleteRequest request = UserDeleteRequest.builder()
-//                    .password("encoded-password")
-//                    .build();
-//
-//            // when
-//            userService.deleteUser(authUser, request);
-//
-//            // then
-//            verify(imageService, never()).delete(anyString());
-//        }
-//
-//        @Test
-//        void 카카오_소셜유저_탈퇴_시_unlink_호출됨() {
-//            // given
-//            User socialUser = createSocialUser(OAuthProvider.KAKAO, "kakao-user-id");
-//            given(userRepository.findById(userId)).willReturn(Optional.of(socialUser));
-//
-//            UserDeleteRequest request = UserDeleteRequest.builder().build();
-//
-//            // when
-//            SimpleUserResponse response = userService.deleteUser(authUser, request);
-//
-//            // then
-//            verify(kakaoAuthService).unlinkKakaoByAdminKey("kakao-user-id");
-//            assertEquals(userId, response.getId());
-//        }
-//
-//        @Test
-//        void 네이버_소셜유저_탈퇴_시_unlink_호출되지_않고_성공() {
-//            // given
-//            User socialUser = createSocialUser(OAuthProvider.NAVER, "naver-user-id");
-//            given(userRepository.findById(userId)).willReturn(Optional.of(socialUser));
-//
-//            UserDeleteRequest request = UserDeleteRequest.builder().build();
-//
-//            // when
-//            SimpleUserResponse response = userService.deleteUser(authUser, request);
-//
-//            // then
-//            // unlink 호출 없음, 로그만 남김
-//            assertEquals(userId, response.getId());
-//        }
+        @Test
+        void 비밀번호가_없으면_예외처리() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            UserDeleteRequest request = UserDeleteRequest.builder()
+                    .password(null)
+                    .build();
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    userService.deleteUser(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN)
+            );
+            assertEquals(ErrorCode.PASSWORD_REQUIRED.getDefaultMessage(), exception.getMessage());
+        }
+
+        @Test
+        void 비밀번호_일치하지_않으면_예외처리() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+            UserDeleteRequest request = UserDeleteRequest.builder()
+                    .password("wrong-password")
+                    .build();
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    userService.deleteUser(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN)
+            );
+            assertEquals(ErrorCode.INCORRECT_PASSWORD.getDefaultMessage(), exception.getMessage());
+        }
+
+        @Test
+        void 탈퇴_성공_이미지있는_유저는_이미지_삭제() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+            UserDeleteRequest request = UserDeleteRequest.builder()
+                    .password("encoded-password")
+                    .build();
+
+            // when
+            SimpleUserResponse response = userService.deleteUser(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN);
+
+            // then
+            assertEquals(USER_ID, response.getId());
+            verify(imageService).delete("image-url");
+            verify(tokenService).deleteRefreshToken(REFRESH_TOKEN);
+            verify(tokenService).addToBlacklist(ACCESS_TOKEN, USER_ID, BlacklistReason.WITHDRAWAL);
+        }
+
+        @Test
+        void 탈퇴_성공_이미지없는_유저는_이미지_삭제_안함() {
+            // given
+            user.updateImageUrl(null);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+            UserDeleteRequest request = UserDeleteRequest.builder()
+                    .password("encoded-password")
+                    .build();
+
+            // when
+            SimpleUserResponse response = userService.deleteUser(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN);
+
+            // then
+            assertEquals(USER_ID, response.getId());
+            verify(imageService, never()).delete(anyString());
+            verify(tokenService).deleteRefreshToken(REFRESH_TOKEN);
+            verify(tokenService).addToBlacklist(ACCESS_TOKEN, USER_ID, BlacklistReason.WITHDRAWAL);
+        }
+
+        @Test
+        void 카카오_소셜유저_탈퇴_시_unlink_호출됨() {
+            // given
+            User socialUser = createSocialUser(OAuthProvider.KAKAO, "kakao-user-id");
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(socialUser));
+
+            UserDeleteRequest request = UserDeleteRequest.builder().build();
+
+            // when
+            SimpleUserResponse response = userService.deleteUser(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN);
+
+            // then
+            verify(kakaoAuthService).unlinkKakaoByAdminKey("kakao-user-id");
+            assertEquals(USER_ID, response.getId());
+            verify(tokenService).deleteRefreshToken(REFRESH_TOKEN);
+            verify(tokenService).addToBlacklist(ACCESS_TOKEN, USER_ID, BlacklistReason.WITHDRAWAL);
+        }
+
+        @Test
+        void 네이버_소셜유저_탈퇴_시_unlink_호출되지_않고_성공() {
+            // given
+            User socialUser = createSocialUser(OAuthProvider.NAVER, "naver-user-id");
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(socialUser));
+
+            UserDeleteRequest request = UserDeleteRequest.builder().build();
+
+            // when
+            SimpleUserResponse response = userService.deleteUser(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN);
+
+            // then
+            // unlink 호출 없음, 로그만 남김
+            assertEquals(USER_ID, response.getId());
+            verify(tokenService).deleteRefreshToken(REFRESH_TOKEN);
+            verify(tokenService).addToBlacklist(ACCESS_TOKEN, USER_ID, BlacklistReason.WITHDRAWAL);
+        }
     }
 
     @Nested
     class 비밀번호_변경 {
 
-//        @Test
-//        void 소셜유저면_예외_발생() {
-//            // given
-//            User socialUser = createSocialUser(OAuthProvider.KAKAO, "kakao-user-id");
-//            given(userRepository.findById(userId)).willReturn(Optional.of(socialUser));
-//
-//            UpdatePasswordRequest request = UpdatePasswordRequest.builder().build();
-//
-//            // when & then
-//            HandledException exception = assertThrows(HandledException.class, () ->
-//                    userService.updatePassword(authUser, request)
-//            );
-//            assertEquals(ErrorCode.UNSUPPORTED_SOCIAL_USER_OPERATION.getDefaultMessage(), exception.getMessage());
-//        }
-//
-//        @Test
-//        void 비밀번호_입력이_없으면_예외_발생() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//
-//            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
-//                    .password(null)
-//                    .newPassword("")
-//                    .build();
-//
-//            // when & then
-//            HandledException exception = assertThrows(HandledException.class, () ->
-//                    userService.updatePassword(authUser, request)
-//            );
-//            assertEquals(ErrorCode.MISSING_PASSWORD.getDefaultMessage(), exception.getMessage());
-//        }
-//
-//        @Test
-//        void 새_비밀번호_형식_틀리면_예외_발생() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//
-//            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
-//                    .password("encoded-password")
-//                    .newPassword("0000") // 규칙에 안 맞는 비밀번호
-//                    .build();
-//
-//            // when & then
-//            HandledException exception = assertThrows(HandledException.class, () ->
-//                    userService.updatePassword(authUser, request)
-//            );
-//            assertEquals(ErrorCode.INVALID_PASSWORD_FORMAT.getDefaultMessage(), exception.getMessage());
-//        }
-//
-//        @Test
-//        void 비밀번호_일치하지_않으면_예외_발생() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
-//
-//            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
-//                    .password("wrong-password")
-//                    .newPassword("newPassword123")
-//                    .build();
-//
-//            // when & then
-//            HandledException exception = assertThrows(HandledException.class, () ->
-//                    userService.updatePassword(authUser, request)
-//            );
-//            assertEquals(ErrorCode.INCORRECT_PASSWORD.getDefaultMessage(), exception.getMessage());
-//        }
-//
-//        @Test
-//        void 비밀번호_변경_성공() {
-//            // given
-//            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-//            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-//
-//            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
-//                    .password("encoded-password")
-//                    .newPassword("newPassword123")
-//                    .build();
-//
-//            // when
-//            SimpleUserResponse response = userService.updatePassword(authUser, request);
-//
-//            // then
-//            assertEquals(userId, response.getId());
-//        }
+        @Test
+        void 소셜유저면_예외처리() {
+            // given
+            User socialUser = createSocialUser(OAuthProvider.KAKAO, "kakao-user-id");
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(socialUser));
+
+            UpdatePasswordRequest request = UpdatePasswordRequest.builder().build();
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    userService.updatePassword(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN)
+            );
+            assertEquals(ErrorCode.UNSUPPORTED_SOCIAL_USER_OPERATION.getDefaultMessage(), exception.getMessage());
+        }
+
+        @Test
+        void 비밀번호_입력이_없으면_예외처리() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
+                    .password(null)
+                    .newPassword("")
+                    .build();
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    userService.updatePassword(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN)
+            );
+            assertEquals(ErrorCode.PASSWORD_REQUIRED.getDefaultMessage(), exception.getMessage());
+        }
+
+        @Test
+        void 새_비밀번호_형식_틀리면_예외처리() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
+                    .password("encoded-password")
+                    .newPassword("0000") // 규칙에 안 맞는 비밀번호
+                    .build();
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    userService.updatePassword(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN)
+            );
+            assertEquals(ErrorCode.PASSWORD_FORMAT_INVALID.getDefaultMessage(), exception.getMessage());
+        }
+
+        @Test
+        void 비밀번호_일치하지_않으면_예외처리() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
+                    .password("wrong-password")
+                    .newPassword("newPassword123")
+                    .build();
+
+            // when & then
+            HandledException exception = assertThrows(HandledException.class, () ->
+                    userService.updatePassword(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN)
+            );
+            assertEquals(ErrorCode.INCORRECT_PASSWORD.getDefaultMessage(), exception.getMessage());
+        }
+
+        @Test
+        void 비밀번호_변경_성공() {
+            // given
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+            UpdatePasswordRequest request = UpdatePasswordRequest.builder()
+                    .password("encoded-password")
+                    .newPassword("newPassword123")
+                    .build();
+
+            // when
+            SimpleUserResponse response = userService.updatePassword(authUser, request, REFRESH_TOKEN, ACCESS_TOKEN);
+
+            // then
+            assertEquals(USER_ID, response.getId());
+            verify(tokenService).deleteRefreshToken(REFRESH_TOKEN);
+            verify(tokenService).addToBlacklist(ACCESS_TOKEN, USER_ID, BlacklistReason.PASSWORD_CHANGE);
+        }
     }
 
     @Nested
     class 프로필_조회 {
 
         @Test
-        void 유저가_존재하지_않으면_예외_발생() {
+        void 유저가_존재하지_않으면_예외처리() {
             // given
-            given(userRepository.findById(userId)).willReturn(Optional.empty());
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
@@ -328,7 +349,7 @@ class UserServiceTest {
         @Test
         void 프로필_조회_성공() {
             // given
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
             // when
             UserProfileResponse response = userService.getUserProfile(authUser);
@@ -348,7 +369,7 @@ class UserServiceTest {
         @Test
         void 기존이미지와_다르면_삭제후_업데이트_성공() {
             // given
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
             String oldImageUrl = user.getImageUrl();
             String newImageUrl = "new-image.jpg";
             UpdateProfileRequest request = UpdateProfileRequest.builder()
@@ -373,7 +394,7 @@ class UserServiceTest {
         void 기존_이미지가_없다면_삭제되지_않고_업데이트_성공() {
             // given
             user.updateImageUrl(null); // 기존 이미지 없음
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
             String newImageUrl = "new-image.jpg";
             UpdateProfileRequest request = UpdateProfileRequest.builder()
                     .imageUrl(newImageUrl)
@@ -390,7 +411,7 @@ class UserServiceTest {
         @Test
         void 이미지가_같으면_삭제하지_않고_업데이트_성공() {
             // given
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
             String sameImageUrl = user.getImageUrl(); // 같은 URL
             UpdateProfileRequest request = UpdateProfileRequest.builder()
                     .imageUrl(sameImageUrl)
@@ -407,7 +428,7 @@ class UserServiceTest {
         @Test
         void 이미지_요청이_없으면_이미지_삭제및_업데이트_없이_성공() {
             // given
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
 
             UpdateProfileRequest request = UpdateProfileRequest.builder()
                     .imageUrl(null) // 이미지 변경 요청 없음


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #140 
close #141 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
### Redis 관련 처리

- [x] `createRefreshToken()` 내 Redis 저장 실패 시 예외 처리 및 로그 기록  
- [x] `validateRefreshToken()` 내 Redis 장애 시 예외 처리  
- [x] `deleteRefreshToken()` 내 Redis 삭제 실패 시 로그 기록  
- [x] `addToBlacklist()` 내 Redis 블랙리스트 저장 실패 시 로그 기록  

### OAuth WebClient 리팩토링

- [x] `.onStatus()`를 통한 HTTP 4xx/5xx 상태 코드 분기 처리  
- [x] `WebClientRequestException` 발생 시 로그 및 예외 처리  
- [x] `access_token` 파싱 로직 유틸 클래스로 분리: `OAuthResponseParser.extractAccessToken()`  
- [x] `KakaoAuthService`, `NaverAuthService`에 유틸 적용  

### S3 Presigned URL 예외 처리

- [x] `generatePresignedUrl()` 내 S3 예외 처리 (`S3Exception`, `SdkClientException`, `IllegalArgumentException`) 추가  
- [x] Presigned URL 생성 실패 시 `HandledException`으로 변환 및 로그 기록  

### 로그 및 에러코드 정리

- [x] 로그 prefix 통일: `[Redis]`, `[OAuth]` , `[S3]`
- [x] ErrorCode 도메인별 분리 (`AUTH`, `USER`)  
- [x] 의미가 모호한 에러코드 리네이밍  
  - 예: `FAILED_TO_PARSE_OAUTH_TOKEN` → `OAUTH_RESPONSE_PARSING_FAILED`

### 테스트 코드

- [x] 변경된 로직에 맞춰 기존 테스트 코드를 수정하고, 누락된 예외 케이스 테스트도 보완
- [x] 아래 이슈에 대한 변경사항 반영
  - #130 
  - #132 
  - #140 


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- [리팩토링 사유 정리](https://www.notion.so/teamsparta/1da2dc3ef51480fc9c49d54c853a0d5b?pvs=4)