### PR TITLE
[test] 예약 API(Redisson 락) 테스트 코드 작성 및 기존 테스트 수정

### DIFF
--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #145 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 기존 예약 생성 테스트 코드 오류 수정
- [X] Redisson 적용 예약 생성 API 테스트 코드 작성(`makeReservationWithLock()`)
- [X] 리뷰 작성 가능 여부 검증 테스트 추가(`validateCreateRating()`)
  - [X] 예약 인원이 여유 있을 때 true 반환 검증
  - [X] 예약 인원이 정원을 초과했을 때 false 반환 검증  
- [X] 빈자리 여부 조회 테스트 추가(`hasVacancyDate()`)
  - [X] 리뷰 가능한 예약이 있을 때 정상 통과
  - [X] 리뷰 가능한 예약이 없을 때 예외 발생 검증

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- Store 기본 세팅 시 `capacity` 필드 추가 
- `hasVacancy()`는 사용하지 않는 메서드여서 테스트 코드 미작성

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/3faabd91-e1b0-4c0b-a086-4cda7a48c90d)

