### PR TITLE
[refactor] 이벤트 API Redisson AOP 방식으로 구조 개선

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/EventJoinExecutor.java
+++ b/src/main/java/org/example/tablenow/domain/event/EventJoinExecutor.java
@@ -1,0 +1,71 @@
+package org.example.tablenow.domain.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.event.dto.response.EventJoinResponseDto;
+import org.example.tablenow.domain.event.entity.Event;
+import org.example.tablenow.domain.event.entity.EventJoin;
+import org.example.tablenow.domain.event.repository.EventJoinRepository;
+import org.example.tablenow.domain.event.repository.EventRepository;
+import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventJoinExecutor {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final EventRepository eventRepository;
+    private final EventJoinRepository eventJoinRepository;
+    private static final String EVENT_JOIN_PREFIX = "event:join:";
+
+    @Transactional
+    public EventJoinResponseDto execute(Long eventId, AuthUser authUser) {
+        User user = User.fromAuthUser(authUser);
+        String userId = String.valueOf(user.getId());
+        String zsetKey = "event:join:" + eventId;
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new HandledException(ErrorCode.EVENT_NOT_FOUND));
+
+        event.validateOpenStatus();
+
+        Boolean added = redisTemplate.opsForZSet().add(zsetKey, userId, System.currentTimeMillis());
+        if (Boolean.FALSE.equals(added)) {
+            throw new HandledException(ErrorCode.EVENT_ALREADY_JOINED);
+        }
+
+        Long rank = redisTemplate.opsForZSet().rank(zsetKey, userId);
+        if (rank == null || rank >= event.getLimitPeople()) {
+            redisTemplate.opsForZSet().remove(zsetKey, userId);
+            throw new HandledException(ErrorCode.EVENT_FULL);
+        }
+
+        try {
+            EventJoin eventJoin = saveEventJoin(event, user);
+            log.info("이벤트 신청 성공: eventJoinId={}, user={}, event={}", eventJoin.getId(), user.getEmail(), eventId);
+            return EventJoinResponseDto.fromEventJoin(eventJoin);
+        } catch (Exception e) {
+            redisTemplate.opsForZSet().remove(zsetKey, String.valueOf(user.getId()));
+            log.warn("DB insert 실패로 Redis 자리 반환: userId={}, eventId={}", user.getId(), eventId);
+            throw e;
+        }
+    }
+
+    @Transactional
+    protected EventJoin saveEventJoin(Event event, User user) {
+        EventJoin eventJoin = EventJoin.builder()
+                .user(user)
+                .event(event)
+                .build();
+
+        return eventJoinRepository.save(eventJoin);
+    }
+}
+

--- a/src/main/java/org/example/tablenow/domain/event/EventJoinExecutor.java
+++ b/src/main/java/org/example/tablenow/domain/event/EventJoinExecutor.java
@@ -29,7 +29,7 @@ public class EventJoinExecutor {
     public EventJoinResponseDto execute(Long eventId, AuthUser authUser) {
         User user = User.fromAuthUser(authUser);
         String userId = String.valueOf(user.getId());
-        String zsetKey = "event:join:" + eventId;
+        String zsetKey = EVENT_JOIN_PREFIX + eventId;
 
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new HandledException(ErrorCode.EVENT_NOT_FOUND));

--- a/src/main/java/org/example/tablenow/domain/event/controller/EventController.java
+++ b/src/main/java/org/example/tablenow/domain/event/controller/EventController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.example.tablenow.domain.event.dto.request.EventRequestDto;
 import org.example.tablenow.domain.event.dto.request.EventUpdateRequestDto;
+import org.example.tablenow.domain.event.dto.response.EventCloseResponseDto;
 import org.example.tablenow.domain.event.dto.response.EventDeleteResponseDto;
 import org.example.tablenow.domain.event.dto.response.EventResponseDto;
 import org.example.tablenow.domain.event.enums.EventStatus;
@@ -41,6 +42,12 @@ public class EventController {
     @DeleteMapping("/v1/admin/events/{id}")
     public ResponseEntity<EventDeleteResponseDto> deleteEvent(@PathVariable Long id) {
         return ResponseEntity.ok(eventService.deleteEvent(id));
+    }
+
+    @Secured(UserRole.Authority.ADMIN)
+    @PatchMapping("/v1/admin/events/{id}/close")
+    public ResponseEntity<EventCloseResponseDto> closeEvent(@PathVariable Long id) {
+        return ResponseEntity.ok(eventService.closeEvent(id));
     }
 
     @GetMapping("/v1/events")

--- a/src/main/java/org/example/tablenow/domain/event/controller/EventJoinController.java
+++ b/src/main/java/org/example/tablenow/domain/event/controller/EventJoinController.java
@@ -19,26 +19,26 @@ public class EventJoinController {
     private final EventJoinService eventJoinService;
 
     @PostMapping("/v1/events/{eventId}/join")
-    public ResponseEntity<EventJoinResponseDto> joinEvent(
+    public ResponseEntity<EventJoinResponseDto> joinEventWithoutLock(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long eventId
     ) {
-        return ResponseEntity.ok(eventJoinService.joinEvent(eventId, authUser));
+        return ResponseEntity.ok(eventJoinService.joinEventWithoutLock(eventId, authUser));
     }
 
     @PostMapping("/v2/events/{eventId}/join")
-    public ResponseEntity<EventJoinResponseDto> joinEventV2(
+    public ResponseEntity<EventJoinResponseDto> joinEventWithDBLock(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long eventId
     ) {
-        return ResponseEntity.ok(eventJoinService.joinEventV2(eventId, authUser));
+        return ResponseEntity.ok(eventJoinService.joinEventWithDBLock(eventId, authUser));
     }
 
     @PostMapping("/v3/events/{eventId}/join")
-    public ResponseEntity<EventJoinResponseDto> joinEventV3(
+    public ResponseEntity<EventJoinResponseDto> joinEventWithLock(
             @AuthenticationPrincipal AuthUser authUser,
             @PathVariable Long eventId
     ) {
-        return ResponseEntity.ok(eventJoinService.joinEventV3(eventId, authUser));
+        return ResponseEntity.ok(eventJoinService.joinEventWithRedissonLock(eventId, authUser));
     }
 }

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventCloseResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventCloseResponseDto.java
@@ -1,0 +1,28 @@
+package org.example.tablenow.domain.event.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.tablenow.domain.event.entity.Event;
+import org.example.tablenow.domain.event.enums.EventStatus;
+
+@Getter
+public class EventCloseResponseDto {
+    private final Long eventId;
+    private final EventStatus status;
+    private final String message;
+
+    @Builder
+    public EventCloseResponseDto(Long eventId, EventStatus status, String message) {
+        this.eventId = eventId;
+        this.status = status;
+        this.message = message;
+    }
+
+    public static EventCloseResponseDto fromEvent(Event event) {
+        return EventCloseResponseDto.builder()
+                .eventId(event.getId())
+                .status(event.getStatus())
+                .message("이벤트가 성공적으로 종료되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/entity/Event.java
+++ b/src/main/java/org/example/tablenow/domain/event/entity/Event.java
@@ -70,6 +70,10 @@ public class Event extends TimeStamped {
         changeStatus(EventStatus.OPENED);
     }
 
+    public void close() {
+        changeStatus(EventStatus.CLOSED);
+    }
+
     public void validateOpenStatus() {
         if (this.status != EventStatus.OPENED) {
             throw new HandledException(ErrorCode.EVENT_NOT_OPENED);

--- a/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
@@ -13,7 +13,6 @@ import org.example.tablenow.global.annotation.DistributedLock;
 import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +26,6 @@ public class EventJoinService {
 
     private final EventJoinRepository eventJoinRepository;
     private final EventRepository eventRepository;
-    private final StringRedisTemplate redisTemplate;
     private final EventJoinExecutor eventJoinExecutor;
 
     private static final String EVENT_LOCK_KEY_PREFIX = "lock:event";

--- a/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
@@ -2,24 +2,23 @@ package org.example.tablenow.domain.event.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.event.EventJoinExecutor;
 import org.example.tablenow.domain.event.dto.response.EventJoinResponseDto;
 import org.example.tablenow.domain.event.entity.Event;
 import org.example.tablenow.domain.event.entity.EventJoin;
 import org.example.tablenow.domain.event.repository.EventJoinRepository;
 import org.example.tablenow.domain.event.repository.EventRepository;
 import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.global.annotation.DistributedLock;
 import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -28,16 +27,13 @@ public class EventJoinService {
 
     private final EventJoinRepository eventJoinRepository;
     private final EventRepository eventRepository;
-    private final RedissonClient redissonClient;
     private final StringRedisTemplate redisTemplate;
+    private final EventJoinExecutor eventJoinExecutor;
 
-    private static final String EVENT_JOIN_PREFIX = "event:join:";
-    private static final String EVENT_LOCK_PREFIX = "lock:event:";
-    private static final long LOCK_WAIT_TIME = 3L;
-    private static final long LOCK_LEASE_TIME = 3L;
+    private static final String EVENT_LOCK_KEY_PREFIX = "lock:event";
 
     @Transactional
-    public EventJoinResponseDto joinEvent(Long eventId, AuthUser authUser) {
+    public EventJoinResponseDto joinEventWithoutLock(Long eventId, AuthUser authUser) {
         User user = User.fromAuthUser(authUser);
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new HandledException(ErrorCode.EVENT_NOT_FOUND));
@@ -62,7 +58,7 @@ public class EventJoinService {
     }
 
     @Transactional
-    public EventJoinResponseDto joinEventV2(Long eventId, AuthUser authUser) {
+    public EventJoinResponseDto joinEventWithDBLock(Long eventId, AuthUser authUser) {
         User user = User.fromAuthUser(authUser);
         Event event = eventRepository.findByIdForUpdate(eventId)
                 .orElseThrow(() -> new HandledException(ErrorCode.EVENT_NOT_FOUND));
@@ -86,80 +82,13 @@ public class EventJoinService {
         return EventJoinResponseDto.fromEventJoin(eventJoin);
     }
 
-    public EventJoinResponseDto joinEventV3(Long eventId, AuthUser authUser) {
-        String lockKey = EVENT_LOCK_PREFIX + eventId;
-        RLock lock = redissonClient.getLock(lockKey);
-
-        try {
-            if (!lock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS)) {
-                log.warn("락 획득 실패: {}", lockKey);
-                throw new HandledException(ErrorCode.EVENT_LOCK_TIMEOUT);
-            }
-
-            return handleJoinLogic(eventId, authUser);
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("인터럽트 발생", e);
-        } catch (Exception e) {
-            throw new RuntimeException("이벤트 신청 중 오류 발생", e);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
-    }
-
-    private EventJoinResponseDto handleJoinLogic(Long eventId, AuthUser authUser) {
-        User user = User.fromAuthUser(authUser);
-        String zsetKey = EVENT_JOIN_PREFIX + eventId;
-
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new HandledException(ErrorCode.EVENT_NOT_FOUND));
-
-        event.validateOpenStatus();
-        validateEventNotAlreadyJoined(zsetKey, user);
-        validateEventCapacity(zsetKey, event.getLimitPeople(), event);
-
-        try {
-            EventJoin eventJoin = saveEventJoin(event, user);
-            log.info("이벤트 신청 성공: eventJoinId={}, user={}, event={}", eventJoin.getId(), user.getEmail(), eventId);
-            return EventJoinResponseDto.fromEventJoin(eventJoin);
-        } catch (Exception e) {
-            redisTemplate.opsForZSet().remove(zsetKey, String.valueOf(user.getId()));
-            log.warn("DB insert 실패로 Redis 자리 반환: userId={}, eventId={}", user.getId(), eventId);
-            throw e;
-        }
-    }
-
-    private void validateEventNotAlreadyJoined(String zsetKey, User user) {
-        Boolean added = redisTemplate.opsForZSet().add(zsetKey, String.valueOf(user.getId()), System.currentTimeMillis());
-        if (Boolean.FALSE.equals(added)) {
-            throw new HandledException(ErrorCode.EVENT_ALREADY_JOINED);
-        }
-        redisTemplate.expire(zsetKey, Duration.ofHours(1));
-    }
-
-    private void validateEventCapacity(String zsetKey, int limit, Event event) {
-        Long current = redisTemplate.opsForZSet().zCard(zsetKey);
-
-        if (current != null && current >= limit) {
-            long dbCount = eventJoinRepository.countByEvent(event);
-
-            if (dbCount >= limit) {
-                throw new HandledException(ErrorCode.EVENT_FULL);
-            }
-        }
-    }
-
-    @Transactional
-    protected EventJoin saveEventJoin(Event event, User user) {
-        EventJoin eventJoin = EventJoin.builder()
-                .user(user)
-                .event(event)
-                .build();
-
-        return eventJoinRepository.save(eventJoin);
+    @DistributedLock(
+            prefix = EVENT_LOCK_KEY_PREFIX,
+            key = "#eventId"
+    )
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public EventJoinResponseDto joinEventWithRedissonLock(Long eventId, AuthUser authUser) {
+        return eventJoinExecutor.execute(eventId, authUser);
     }
 
     public List<User> getUsersByEventId(Long id) {

--- a/src/test/java/org/example/tablenow/domain/event/EventJoinServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/event/EventJoinServiceTest.java
@@ -84,7 +84,7 @@ public class EventJoinServiceTest {
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    eventJoinService.joinEvent(eventId, authUser)
+                    eventJoinService.joinEventWithoutLock(eventId, authUser)
             );
 
             assertEquals(ErrorCode.EVENT_NOT_OPENED.getDefaultMessage(), exception.getMessage());
@@ -98,7 +98,7 @@ public class EventJoinServiceTest {
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    eventJoinService.joinEvent(eventId, authUser)
+                    eventJoinService.joinEventWithoutLock(eventId, authUser)
             );
 
             assertEquals(ErrorCode.EVENT_ALREADY_JOINED.getDefaultMessage(), exception.getMessage());
@@ -113,7 +113,7 @@ public class EventJoinServiceTest {
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
-                    eventJoinService.joinEvent(eventId, authUser)
+                    eventJoinService.joinEventWithoutLock(eventId, authUser)
             );
 
             assertEquals(ErrorCode.EVENT_FULL.getDefaultMessage(), exception.getMessage());
@@ -128,7 +128,7 @@ public class EventJoinServiceTest {
             given(eventJoinRepository.save(any(EventJoin.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            EventJoinResponseDto response = eventJoinService.joinEvent(eventId, authUser);
+            EventJoinResponseDto response = eventJoinService.joinEventWithoutLock(eventId, authUser);
 
             // then
             assertNotNull(response);


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #144

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] `@DistributedLock` AOP 기반 락 구조 적용
- [X] 신청 로직을 `EventJoinExecutor` 컴포넌트로 분리
- [X] Redis ZSet 기반 중복 신청 방지 + 선착순 정원 체크 구현
- [X] zCard → rank 기반으로 로직 전환
- [X] TTL 제거
- [X] 이벤트 닫는 API 추가(`closeEvent()`)


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- TTL은 Redis 데이터를 자동 삭제하지만, **ZSet이 없어지면 중복 신청 방지/정원 체크가 무력화**되므로 정합성을 보장하지 못합니다. 따라서 **TTL을 삭제** 후 이벤트를 닫는 API를 만들었습니다. **이벤트 닫힘/삭제 상태**가 되면 ZSet에 든 데이터를 삭제합니다.
- 기존 `ZSet.zCard()`로 인원수를 체크하고, 정원이 넘으면 DB count를 추가로 확인하는 구조에서 유저를 ZSet에 추가한 후 `rank()`를 확인하여, 정해진 정원 이내일 때만 insert되도록 수정했습니다.
- [ZSet이 락 밖에서 실행되어 발생하는 오류](https://www.notion.so/teamsparta/ZSet-1dc2dc3ef5148076b19fc16fa9834097?pvs=4)
- [zCard → rank 기반으로 정원 체크 로직 개선](https://www.notion.so/teamsparta/zCard-rank-1dc2dc3ef5148070a3fccfa652b63cd5?pvs=4)

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/4a13faf6-5d3c-41d3-b3e0-26e4998f5278)
