### PR TITLE
[feat] RabbitQM 기반 예약 리마인드 알림 기능 구현

### DIFF
--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
@@ -1,0 +1,35 @@
+package org.example.tablenow.domain.reservation.message.customer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneOffset;
+
+import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESERVATION_REMINDER_REGISTER_QUEUE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderRegisterConsumer {
+    private final StringRedisTemplate redisTemplate;
+    private static final String REMINDER_ZSET_KEY = "reminder:zset";
+
+    @RabbitListener(queues = RESERVATION_REMINDER_REGISTER_QUEUE)
+    public void handleReminderRegister(ReminderMessage message) {
+        try {
+            String reservationId = String.valueOf(message.getReservationId());
+            double score = message.getRemindAt().toEpochSecond(ZoneOffset.UTC);
+
+            redisTemplate.opsForZSet().add(REMINDER_ZSET_KEY, reservationId, score);
+
+            log.info("[ReminderRegisterConsumer] 리마인드 알림 등록 완료 → reservationId={}, remindAt={}",
+                    reservationId, message.getRemindAt());
+        } catch (Exception e) {
+            log.error("[ReminderRegisterConsumer] 리마인드 등록 실패 → message={}", message, e);
+        }
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
@@ -1,0 +1,64 @@
+package org.example.tablenow.domain.reservation.message.customer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.notification.dto.request.NotificationRequestDto;
+import org.example.tablenow.domain.notification.enums.NotificationType;
+import org.example.tablenow.domain.notification.service.NotificationService;
+import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
+import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.domain.user.service.UserService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESERVATION_REMINDER_SEND_QUEUE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderSendConsumer {
+    private final NotificationService notificationService;
+
+    private static final String RESERVATION_REMINDER_MSG_TEMPLATE = "%s에 %s 예약이 있습니다!";
+    private final UserService userService;
+
+    @RabbitListener(queues = RESERVATION_REMINDER_SEND_QUEUE)
+    public void consume(ReminderMessage message) {
+        if (!isValid(message)) return;
+
+        User user = userService.getUser(message.getUserId());
+
+        if (user == null) {
+            log.warn("[ReminderSendConsumer] 유저를 찾을 수 없음 → userId={}", message.getUserId());
+            return;
+        }
+
+        sendNotification(user, message);
+    }
+
+    private boolean isValid(ReminderMessage message) {
+        if (message == null || message.getUserId() == null || message.getStoreId() == null || message.getReservationId() == null) {
+            log.warn("[ReminderSendConsumer] 잘못된 메시지 수신 → {}", message);
+            return false;
+        }
+        return true;
+    }
+
+    private void sendNotification(User user, ReminderMessage message) {
+        try {
+            NotificationRequestDto dto = NotificationRequestDto.builder()
+                    .userId(user.getId())
+                    .storeId(message.getStoreId())
+                    .type(NotificationType.REMIND)
+                    .content(String.format(RESERVATION_REMINDER_MSG_TEMPLATE, message.getReservedAt(), message.getStoreName()))
+                    .build();
+
+            notificationService.createNotification(dto);
+
+            log.info("[ReminderSendConsumer][Notification] 알림 전송 완료 → userId={}, reservationId={}", user.getId(), message.getReservationId());
+
+        } catch (Exception e) {
+            log.error("[ReminderSendConsumer][Notification] 알림 전송 실패 → userId={}, reservationId={}", user.getId(), message.getReservationId(), e);
+        }
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
@@ -34,6 +34,7 @@ public class ReminderSendConsumer {
         }
 
         sendNotification(user, message);
+        log.info("[ReminderSendConsumer] 리마인드 알림 전송 완료 → reservationId={}", message.getReservationId());
     }
 
     private boolean isValid(ReminderMessage message) {

--- a/src/main/java/org/example/tablenow/domain/reservation/message/dto/ReminderMessage.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/dto/ReminderMessage.java
@@ -1,0 +1,38 @@
+package org.example.tablenow.domain.reservation.message.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.tablenow.domain.reservation.entity.Reservation;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ReminderMessage {
+    private final Long reservationId;
+    private final Long userId;
+    private final Long storeId;
+    private final String storeName;
+    private final LocalDateTime reservedAt;
+    private final LocalDateTime remindAt;
+
+    @Builder
+    public ReminderMessage(Long reservationId, Long userId, Long storeId, String storeName, LocalDateTime reservedAt, LocalDateTime remindAt) {
+        this.reservationId = reservationId;
+        this.userId = userId;
+        this.storeId = storeId;
+        this.storeName = storeName;
+        this.reservedAt = reservedAt;
+        this.remindAt = remindAt;
+    }
+
+    public static ReminderMessage fromReservation(Reservation reservation) {
+        return ReminderMessage.builder()
+                .reservationId(reservation.getId())
+                .userId(reservation.getUser().getId())
+                .storeId(reservation.getStore().getId())
+                .storeName(reservation.getStore().getName())
+                .reservedAt(reservation.getReservedAt())
+                .remindAt(reservation.getRemindAt())
+                .build();
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
@@ -21,7 +21,7 @@ public class ReminderRegisterProducer {
                 message
         );
 
-        log.info("[ReminderRegisterProducer] 리마인드 알림 등록 메시지 발행 완료 → userId={}, reservationId={}, remindAt={}",
+        log.info("[ReminderRegisterProducer] 리마인드 알림 등록 메시지 발행 → userId={}, reservationId={}, remindAt={}",
                 message.getUserId(),
                 message.getReservationId(),
                 message.getRemindAt());

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
@@ -1,0 +1,29 @@
+package org.example.tablenow.domain.reservation.message.producer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderRegisterProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public void send(ReminderMessage message) {
+        rabbitTemplate.convertAndSend(
+                RESERVATION_REMINDER_REGISTER_EXCHANGE,
+                RESERVATION_REMINDER_REGISTER_ROUTING_KEY,
+                message
+        );
+
+        log.info("[ReminderRegisterProducer] 리마인드 알림 등록 메시지 발행 완료 → userId={}, reservationId={}, remindAt={}",
+                message.getUserId(),
+                message.getReservationId(),
+                message.getRemindAt());
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
@@ -21,7 +21,7 @@ public class ReminderSendProducer {
                 message
         );
 
-        log.info("[ReminderRegisterProducer] 리마인드 알림 발행 메시지 발행 완료 → userId={}, reservationId={}, remindAt={}",
+        log.info("[ReminderRegisterProducer] 리마인드 알림 발송 메시지 발행 → userId={}, reservationId={}, remindAt={}",
                 message.getUserId(),
                 message.getReservationId(),
                 message.getRemindAt());

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
@@ -1,0 +1,29 @@
+package org.example.tablenow.domain.reservation.message.producer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderSendProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public void send(ReminderMessage message) {
+        rabbitTemplate.convertAndSend(
+                RESERVATION_REMINDER_SEND_EXCHANGE,
+                RESERVATION_REMINDER_SEND_ROUTING_KEY,
+                message
+        );
+
+        log.info("[ReminderRegisterProducer] 리마인드 알림 발행 메시지 발행 완료 → userId={}, reservationId={}, remindAt={}",
+                message.getUserId(),
+                message.getReservationId(),
+                message.getRemindAt());
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/repository/ReservationRepository.java
@@ -67,11 +67,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("""
             SELECT r
             FROM Reservation r
-            JOIN FETCH r.user
             JOIN FETCH r.store
             WHERE r.id = :id
         """)
-    Optional<Reservation> findByIdWithUserAndStore(@Param("id") Long id);
+    Optional<Reservation> findWithStoreById(@Param("id") Long id);
 
     @Query("""
             SELECT COUNT(r) > 0
@@ -81,8 +80,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
               AND r.status = 'COMPLETED'
             """)
     boolean existsReviewableReservation(Long userId, Long storeId);
-
-
-
 
 }

--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReminderScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReminderScheduler.java
@@ -1,0 +1,44 @@
+package org.example.tablenow.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.reservation.entity.Reservation;
+import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
+import org.example.tablenow.domain.reservation.message.producer.ReminderSendProducer;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderScheduler {
+    private static final String ZSET_KEY = "reminder:zset";
+    private final StringRedisTemplate redisTemplate;
+    private final ReminderSendProducer sendProducer;
+    private final ReservationService reservationService;
+
+    @Scheduled(fixedRateString = "60000")
+    public void pollAndSend() {
+        long now = Instant.now().getEpochSecond();
+        Set<String> due = redisTemplate.opsForZSet().rangeByScore(ZSET_KEY, 0, now);
+        if (due == null || due.isEmpty()) return;
+
+        for (String id : due) {
+            try {
+                sendProducer.send(buildMessage(id));
+                redisTemplate.opsForZSet().remove(ZSET_KEY, id);
+            } catch (Exception e) {
+                log.error("[ReminderScheduler] 알림 발송 실패 → reservationId={}", id, e);
+            }
+        }
+    }
+
+    private ReminderMessage buildMessage(String id) {
+        Reservation reservation = reservationService.getReservationWithStore(Long.valueOf(id));
+        return ReminderMessage.fromReservation(reservation);
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
@@ -156,6 +156,11 @@ public class ReservationService {
                 .orElseThrow(() -> new HandledException(ErrorCode.RESERVATION_NOT_FOUND));
     }
 
+    public Reservation getReservationWithStore(Long id) {
+        return reservationRepository.findWithStoreById(id)
+                .orElseThrow(() -> new HandledException(ErrorCode.RESERVATION_NOT_FOUND));
+    }
+
     private void validateUpdatableReservation(User user, Long id, ReservationUpdateRequestDto request, Reservation reservation) {
         validateReservationOwner(reservation, user);
         validateReservationTimeDuplicated(id, request, reservation);

--- a/src/main/java/org/example/tablenow/global/rabbitmq/config/RabbitConfig.java
+++ b/src/main/java/org/example/tablenow/global/rabbitmq/config/RabbitConfig.java
@@ -29,6 +29,7 @@ public class RabbitConfig {
         return BindingBuilder.bind(vacancyQueue()).to(vacancyExchange()).with(VACANCY_ROUTING_KEY);
     }
 
+    // 이벤트 오픈 Queue, Exchange, Binding
     @Bean
     public Queue eventOpenQueue() {
         return new Queue(EVENT_OPEN_QUEUE, true);
@@ -43,6 +44,44 @@ public class RabbitConfig {
     public Binding eventOpenBinding() {
         return BindingBuilder.bind(eventOpenQueue())
                 .to(eventOpenExchange());
+    }
+
+    // 예약 리마인드 등록 Queue, Exchange, Binding
+    @Bean
+    public Queue reminderRegisterQueue() {
+        return new Queue(RESERVATION_REMINDER_REGISTER_QUEUE, true);
+    }
+
+    @Bean
+    public DirectExchange reminderRegisterExchange() {
+        return new DirectExchange(RESERVATION_REMINDER_REGISTER_EXCHANGE);
+    }
+
+    @Bean
+    public Binding reminderRegisterBinding() {
+        return BindingBuilder
+                .bind(reminderRegisterQueue())
+                .to(reminderRegisterExchange())
+                .with(RESERVATION_REMINDER_REGISTER_ROUTING_KEY);
+    }
+
+    // 예약 리마인드 발송 Queue, Exchange, Binding
+    @Bean
+    public DirectExchange reminderSendExchange() {
+        return new DirectExchange(RESERVATION_REMINDER_SEND_EXCHANGE);
+    }
+
+    @Bean
+    public Queue reminderSendQueue() {
+        return new Queue(RESERVATION_REMINDER_SEND_QUEUE, true);
+    }
+
+    @Bean
+    public Binding reminderSendBinding() {
+        return BindingBuilder
+                .bind(reminderSendQueue())
+                .to(reminderSendExchange())
+                .with(RESERVATION_REMINDER_SEND_ROUTING_KEY);
     }
 
     // 공통 설정

--- a/src/main/java/org/example/tablenow/global/rabbitmq/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/rabbitmq/constant/RabbitConstant.java
@@ -7,4 +7,12 @@ public class RabbitConstant {
 
     public static final String EVENT_OPEN_EXCHANGE = "event.open.fanout";
     public static final String EVENT_OPEN_QUEUE = "event.open.queue";
+
+    public static final String RESERVATION_REMINDER_REGISTER_EXCHANGE = "reservation.reminder.register.exchange";
+    public static final String RESERVATION_REMINDER_REGISTER_QUEUE = "reservation.reminder.register.queue";
+    public static final String RESERVATION_REMINDER_REGISTER_ROUTING_KEY = "reservation.reminder.register.key";
+
+    public static final String RESERVATION_REMINDER_SEND_EXCHANGE = "reservation.reminder.send.exchange";
+    public static final String RESERVATION_REMINDER_SEND_QUEUE = "reservation.reminder.send.queue";
+    public static final String RESERVATION_REMINDER_SEND_ROUTING_KEY = "reservation.reminder.send.key";
 }


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #164 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 예약 생성 시 리마인드 알림 등록 메시지 발행
- [X] `ReminderMessage` DTO 생성 (예약 알림 등록/발송 메시지 통합 구조)
- [X] `ReminderRegisterProducer` / `ReminderRegisterConsumer` 구현 및 MQ 발행 구조 설정
- [X] 알림 등록 메세지 수신 시 Redis ZSET(`reminder:zset`)에 예약 ID 등록(`score = remindAt`)
- [X] `ReminderSendProducer` / `ReminderSendConsumer` 구현 및 알림 전송 흐름 완성
- [X] `ReminderScheduler` 추가, Redis ZSET 기반 알림 도래 확인 후 MQ 발행
- [X] `ReservationService`에 `getReservationWithStore()` 메서드 추가 (Lazy 방지)
- [X] `RabbitConfig`에 리마인드용 DirectExchange + Queue + Binding 설정

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- [예약 리마인드 알림 Redis ZSET + RabbitMQ 적용](https://www.notion.so/teamsparta/1de2dc3ef51480cdbe57d6cae2b52ce5)(작성전)
- 예약 리마인드 알림은 **등록 시점과 발송 시점이 다르기 때문에**, 
각각의 책임을 분리하여 Producer/Consumer를 두 쌍으로 구성했습니다.
   - `ReminderRegisterProducer / Consumer`  
    → 예약 생성 시 알림 등록 메시지를 발행하고,  
    → Consumer가 Redis ZSET에 예약 ID를 등록합니다.

  - `ReminderSendProducer / Consumer`  
    → Scheduler가 알림 시간이 도래한 예약을 확인하여 메시지를 발행하고,  
    → Consumer가 알림을 생성합니다.
- 현재는 단일 유저 기준으로 정상 작동을 확인했으나, 
추후 더 많은 알림이 발송되면 지연이 발생할 수도 있어 개선 방향을 생각해보겠습니다.
- MQ 구성은 아래와 같이 분리되어 있습니다.

| 용도 | Exchange | Queue | Routing Key |
|------|----------|--------|-------------|
| 알림 등록 | `reservation.reminder.register.direct` | `reservation.reminder.register.queue` | `reservation.reminder.register.key` |
| 알림 발송 | `reservation.reminder.send.direct` | `reservation.reminder.send.queue` | `reservation.reminder.send.key` |

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
### 로그
![image](https://github.com/user-attachments/assets/4e93ccd4-69fc-4071-8edb-592695610a01)
![image](https://github.com/user-attachments/assets/64b20237-7fac-4b12-88ea-6d350c5c5ce5)

### RabbitMQ
![image](https://github.com/user-attachments/assets/cff14736-0a37-48c7-8f5e-8ab7730b60ac)
![image](https://github.com/user-attachments/assets/bf7e3bf6-9320-4057-8ce8-64502f9da653)
