### PR TITLE
[refactor] 가게 데이터 변경 시 Redis + ES 반영

### DIFF
--- a/src/main/java/org/example/tablenow/domain/store/controller/StoreSearchController.java
+++ b/src/main/java/org/example/tablenow/domain/store/controller/StoreSearchController.java
@@ -2,10 +2,14 @@ package org.example.tablenow.domain.store.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.tablenow.domain.store.dto.response.StoreDocumentResponseDto;
+import org.example.tablenow.domain.store.service.StoreBulkIndexer;
 import org.example.tablenow.domain.store.service.StoreSearchService;
+import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.dto.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,15 +19,26 @@ import org.springframework.web.bind.annotation.*;
 public class StoreSearchController {
 
     private final StoreSearchService storeSearchService;
+    private final StoreBulkIndexer storeBulkIndexer;
 
+
+    // Elastic Index 수동 갱신
+    @Secured(UserRole.Authority.ADMIN)
+    @PostMapping("/v3/stores/_index")
+    public ResponseEntity<Void> bulkIndexing() {
+        storeBulkIndexer.bulkIndex();
+        return ResponseEntity.ok().build();
+    }
+
+    // 가게 목록 조회 (ElasticSearch + Redis)
     @GetMapping("/v3/stores")
-    public ResponseEntity<Page<StoreDocumentResponseDto>> getStoresV3(@AuthenticationPrincipal AuthUser authUser,
-                                                                      @RequestParam(defaultValue = "1") int page,
-                                                                      @RequestParam(defaultValue = "10") int size,
-                                                                      @RequestParam(defaultValue = "ratingCount") String sort,
-                                                                      @RequestParam(defaultValue = "desc") String direction,
-                                                                      @RequestParam(required = false) Long categoryId,
-                                                                      @RequestParam(required = false) String keyword) {
+    public ResponseEntity<PageResponse<StoreDocumentResponseDto>> getStoresV3(@AuthenticationPrincipal AuthUser authUser,
+                                                                              @RequestParam(defaultValue = "1") int page,
+                                                                              @RequestParam(defaultValue = "10") int size,
+                                                                              @RequestParam(defaultValue = "ratingCount") String sort,
+                                                                              @RequestParam(defaultValue = "desc") String direction,
+                                                                              @RequestParam(required = false) Long categoryId,
+                                                                              @RequestParam(required = false) String keyword) {
         return ResponseEntity.ok(storeSearchService.getStoresV3(authUser, page, size, sort, direction, categoryId, keyword));
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreDocumentResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreDocumentResponseDto.java
@@ -1,14 +1,12 @@
 package org.example.tablenow.domain.store.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.tablenow.domain.store.entity.StoreDocument;
 
 import java.io.Serializable;
-import java.time.LocalTime;
 
 @Getter
 public class StoreDocumentResponseDto implements Serializable {

--- a/src/main/java/org/example/tablenow/domain/store/message/consumer/StoreConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/consumer/StoreConsumer.java
@@ -1,0 +1,59 @@
+package org.example.tablenow.domain.store.message.consumer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.store.entity.StoreDocument;
+import org.example.tablenow.domain.store.message.dto.StoreEventDto;
+import org.example.tablenow.domain.store.repository.StoreElasticRepository;
+import org.example.tablenow.domain.store.service.StoreSearchService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StoreConsumer {
+
+    private final StoreElasticRepository storeElasticRepository;
+    private final StoreSearchService storeSearchService;
+
+    @RabbitListener(queues = STORE_CREATE_QUEUE)
+    public void handleCreate(StoreEventDto event) {
+        try {
+            StoreDocument storeDocument = event.getStoreDocument();
+            // ElasticSearch 인덱스 업데이트
+            storeElasticRepository.updateStoreIndex(storeDocument);
+            // Redis 캐시 키 탐색 및 선별 삭제
+            storeSearchService.invalidateCacheOnNewStore(storeDocument);
+        } catch (Exception e) {
+            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생", e);
+        }
+    }
+
+    @RabbitListener(queues = STORE_UPDATE_QUEUE)
+    public void handleUpdate(StoreEventDto event) {
+        try {
+            StoreDocument storeDocument = event.getStoreDocument();
+            // ElasticSearch 인덱스 업데이트
+            storeElasticRepository.updateStoreIndex(storeDocument);
+            // Redis 캐시 삭제
+            storeSearchService.invalidateStoreCacheByKey(storeDocument.getId());
+        } catch (Exception e) {
+            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생", e);
+        }
+    }
+
+    @RabbitListener(queues = STORE_DELETE_QUEUE)
+    public void handleDelete(Long storeId) {
+        try {
+            // ElasticSearch 인덱스 삭제
+            storeElasticRepository.deleteStoreIndex(storeId);
+            // Redis 캐시 삭제
+            storeSearchService.invalidateStoreCacheByKey(storeId);
+        } catch (Exception e) {
+            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생", e);
+        }
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/store/message/dto/StoreEventDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/dto/StoreEventDto.java
@@ -1,0 +1,22 @@
+package org.example.tablenow.domain.store.message.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.store.entity.StoreDocument;
+
+import java.io.Serializable;
+
+@Getter
+public class StoreEventDto implements Serializable {
+    private StoreDocument storeDocument;
+
+    @Builder
+    private StoreEventDto(StoreDocument storeDocument) {
+        this.storeDocument = storeDocument;
+    }
+
+    public static StoreEventDto fromStore(Store store) {
+        return new StoreEventDto(StoreDocument.fromStore(store));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/store/message/producer/StoreProducer.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/producer/StoreProducer.java
@@ -1,0 +1,35 @@
+package org.example.tablenow.domain.store.message.producer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.store.message.dto.StoreEventDto;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StoreProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishStoreCreate(Store store) {
+        StoreEventDto event = StoreEventDto.fromStore(store);
+        rabbitTemplate.convertAndSend(STORE_EXCHANGE, STORE_CREATE, event);
+        log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", STORE_CREATE, store.getId());
+    }
+
+    public void publishStoreUpdate(Store store) {
+        StoreEventDto event = StoreEventDto.fromStore(store);
+        rabbitTemplate.convertAndSend(STORE_EXCHANGE, STORE_UPDATE, event);
+        log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", STORE_UPDATE, store.getId());
+    }
+
+    public void publishStoreDelete(Long storeId) {
+        rabbitTemplate.convertAndSend(STORE_EXCHANGE, STORE_DELETE, storeId);
+        log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", STORE_DELETE, storeId);
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/store/service/StoreSearchService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/StoreSearchService.java
@@ -1,32 +1,55 @@
 package org.example.tablenow.domain.store.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.store.dto.response.StoreDocumentResponseDto;
 import org.example.tablenow.domain.store.entity.StoreDocument;
 import org.example.tablenow.domain.store.enums.StoreSortField;
 import org.example.tablenow.domain.store.repository.StoreElasticRepository;
 import org.example.tablenow.domain.store.util.StoreKeyGenerator;
 import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.dto.PageResponse;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.springframework.data.domain.*;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.example.tablenow.domain.store.util.StoreConstant.*;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StoreSearchService {
 
     private final StoreElasticRepository storeElasticRepository;
+    private final TextAnalyzerService textAnalyzerService;
     private final StoreService storeService;
-    private final RedisTemplate<Object, Object> redisTemplate;
-    private static final String SEARCH_KEY_PREFIX = "store:search:";
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final JavaType STORE_PAGE_RESPONSE_TYPE =
+            new ObjectMapper().getTypeFactory()
+                    .constructParametricType(PageResponse.class, StoreDocumentResponseDto.class);
 
     @Transactional(readOnly = true)
-    public Page<StoreDocumentResponseDto> getStoresV3(AuthUser authUser, int page, int size, String sort, String direction, Long categoryId, String keyword) {
+    public PageResponse<StoreDocumentResponseDto> getStoresV3(AuthUser authUser, int page, int size, String sort, String direction, Long categoryId, String keyword) {
         try {
             Sort sortOption = Sort.by(Sort.Direction.fromString(direction), StoreSortField.fromString(sort));
             Pageable pageable = PageRequest.of(page - 1, size, sortOption);
@@ -35,24 +58,92 @@ public class StoreSearchService {
             storeService.savePopularKeyword(authUser, keyword);
 
             // Redis 조회
-            String storeKey = SEARCH_KEY_PREFIX + StoreKeyGenerator.generateStoreListKey(page, size, sort, direction, categoryId, keyword);
-            if (redisTemplate.hasKey(storeKey)) {
-                Object storeCache = redisTemplate.opsForValue().get(storeKey);
-                return (Page<StoreDocumentResponseDto>) storeCache;
+            String storeKey = STORE_SEARCH_KEY + StoreKeyGenerator.generateStoreListKey(page, size, sort, direction, categoryId, keyword);
+            if (stringRedisTemplate.hasKey(storeKey)) {
+                String storeCache = stringRedisTemplate.opsForValue().get(storeKey);
+                if (StringUtils.hasText(storeCache)) {
+                    try {
+                        return objectMapper.readValue(storeCache, STORE_PAGE_RESPONSE_TYPE);
+                    } catch (JsonProcessingException e) {
+                        log.error("[Redis] Value Json 변환 중 에러 발생", e);
+                    }
+                }
             }
 
             // ElasticSearch 조회
             Page<StoreDocument> storeDocuments = storeElasticRepository.searchByKeywordAndCategoryId(keyword, categoryId, pageable);
-            Page<StoreDocumentResponseDto> response = storeDocuments.map(storeDocument -> StoreDocumentResponseDto.fromStoreDocument(storeDocument));
+            PageResponse<StoreDocumentResponseDto> response = new PageResponse<>(storeDocuments.map(StoreDocumentResponseDto::fromStoreDocument));
 
             if (!response.getContent().isEmpty()) {
-                // Redis 캐시 저장
-                redisTemplate.opsForValue().set(storeKey, response);
-                redisTemplate.expire(storeKey, 1, TimeUnit.DAYS);
+                try {
+                    // 검색 결과 Redis 캐시 저장
+                    stringRedisTemplate.opsForValue().set(storeKey, objectMapper.writeValueAsString(response), 1, TimeUnit.DAYS);
+                    // 역인덱스 추가
+                    Long[] storeIds = response.getContent().stream().map(StoreDocumentResponseDto::getStoreId).distinct().toArray(Long[]::new);
+                    for (Long storeId : storeIds) {
+                        stringRedisTemplate.opsForSet().add(STORE_CACHE_KEY + storeId, storeKey);
+                        stringRedisTemplate.expire(STORE_CACHE_KEY + storeId, 1, TimeUnit.DAYS);
+                    }
+                } catch (JsonProcessingException e) {
+                    log.error("[Redis] Value Json 변환 중 에러 발생", e);
+                }
             }
             return response;
         } catch (IllegalArgumentException e) {
             throw new HandledException(ErrorCode.INVALID_ORDER_VALUE);
+        }
+    }
+
+    public void invalidateCacheOnNewStore(StoreDocument storeDocument) {
+        Set<String> keysToDelete = new HashSet<>();
+
+        // 키워드 검색 조건: 가게명 기준 예상 검색어 분석
+        Set<String> keywordTokens = textAnalyzerService.analyzeText(STORE_INDEX_NAME, STORE_ANALYZER_NAME, storeDocument.getName());
+        if (!keywordTokens.isEmpty()) {
+            for (String keyword : keywordTokens) {
+                String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", keyword);
+                Set<String> keywordKeys = scanKeys(pattern);
+                keysToDelete.addAll(keywordKeys);
+            }
+        }
+
+        // 카테고리 검색 조건
+        String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "categoryId", String.valueOf(storeDocument.getCategoryId()));
+        Set<String> categoryKeys = scanKeys(pattern);
+        keysToDelete.addAll(categoryKeys);
+
+        stringRedisTemplate.delete(keysToDelete);
+    }
+
+    private Set<String> scanKeys(String pattern) {
+        Set<String> keys = new HashSet<>();
+        ScanOptions options = ScanOptions.scanOptions().match(pattern).count(1000).build();
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+
+        RedisConnection connection = stringRedisTemplate.getConnectionFactory().getConnection();
+
+        try (Cursor<byte[]> cursor = connection.scan(options)) {
+            while (cursor.hasNext()) {
+                byte[] rawKey = cursor.next();
+                String key = stringSerializer.deserialize(rawKey);
+                if (key != null) {
+                    keys.add(key);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Redis 키 조회 오류 발생: {}", pattern, e);
+        }
+        return keys;
+    }
+
+
+    public void invalidateStoreCacheByKey(Long storeId) {
+        Set<String> cacheKeys = stringRedisTemplate.opsForSet().members(STORE_CACHE_KEY + storeId);
+        if (!cacheKeys.isEmpty()) {
+            // 검색 결과 Redis 캐시 삭제
+            stringRedisTemplate.delete(cacheKeys);
+            // 역인덱스 삭제
+            stringRedisTemplate.delete(STORE_CACHE_KEY + storeId);
         }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/service/TextAnalyzerService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/TextAnalyzerService.java
@@ -1,0 +1,57 @@
+package org.example.tablenow.domain.store.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TextAnalyzerService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${spring.elasticsearch.uris}")
+    private String elasticUrl;
+
+    // Elastic analyzer 호출
+    public Set<String> analyzeText(String indexName, String analyzer, String text) {
+        String endpoint = elasticUrl + "/" + indexName + "/_analyze";
+
+        String requestBody = String.format("{\"analyzer\": \"%s\", \"text\": \"%s\"}", analyzer, text);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(endpoint, entity, String.class);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                JsonNode root = objectMapper.readTree(response.getBody());
+                JsonNode tokens = root.get("tokens");
+
+                Set<String> result = new HashSet<>();
+                for (JsonNode token : tokens) {
+                    result.add(token.get("token").asText());
+                }
+                return result;
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Elasticsearch analyzer 호출 실패", e);
+        }
+
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/store/util/StoreConstant.java
+++ b/src/main/java/org/example/tablenow/domain/store/util/StoreConstant.java
@@ -1,0 +1,17 @@
+package org.example.tablenow.domain.store.util;
+
+public class StoreConstant {
+    // 인기 검색어 랭킹
+    public static final String STORE_KEYWORD_RANK_KEY = "store:keyword";
+    public static final String STORE_KEYWORD_USER_KEY = "store:keyword:user:";
+
+    // 검색 Redis Key
+    public static final String STORE_SEARCH_KEY = "store:search:";
+
+    // 역인덱스 key
+    public static final String STORE_CACHE_KEY = "store:cache-keys:";
+
+    // ElasticSearch
+    public static final String STORE_INDEX_NAME = "store";
+    public static final String STORE_ANALYZER_NAME = "korean_search";
+}

--- a/src/main/java/org/example/tablenow/domain/store/util/StoreKeyGenerator.java
+++ b/src/main/java/org/example/tablenow/domain/store/util/StoreKeyGenerator.java
@@ -14,7 +14,13 @@ public class StoreKeyGenerator {
                 categoryId != null ? categoryId : "",
                 keyword != null ? keyword : ""
         );
-        log.info("key stores: {}", key);
+        log.info("[Radis 키 생성] store:search: {}", key);
+        return key;
+    }
+
+    public static String generateStoreKeyByPattern(String header, String parameter, String keyword) {
+        String key = String.format("*%s*%s=%s*", header, parameter, keyword);
+        log.info("[Radis 패턴 생성] {}", key);
         return key;
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/util/StoreRedisKey.java
+++ b/src/main/java/org/example/tablenow/domain/store/util/StoreRedisKey.java
@@ -1,6 +1,0 @@
-package org.example.tablenow.domain.store.util;
-
-public class StoreRedisKey {
-    public static final String STORE_KEYWORD_RANK_KEY = "store:keyword";
-    public static final String STORE_KEYWORD_USER_KEY = "store:keyword:user:";
-}

--- a/src/main/java/org/example/tablenow/global/config/CacheConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/CacheConfig.java
@@ -6,9 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -22,7 +19,7 @@ public class CacheConfig {
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
         Map<String, RedisCacheConfiguration> configMap = new HashMap<>();
         configMap.put("stores", RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofHours(1)));
+                .entryTtl(Duration.ofDays(1)));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig())

--- a/src/main/java/org/example/tablenow/global/dto/PageResponse.java
+++ b/src/main/java/org/example/tablenow/global/dto/PageResponse.java
@@ -1,0 +1,54 @@
+package org.example.tablenow.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+    private final List<T> content;
+    private final int pageNumber;
+    private final int pageSize;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean last;
+    private final boolean first;
+    private final boolean sorted;
+
+    @Builder
+    @JsonCreator
+    public PageResponse(@JsonProperty("content") List<T> content,
+                        @JsonProperty("pageNumber") int pageNumber,
+                        @JsonProperty("pageSize") int pageSize,
+                        @JsonProperty("totalElements") long totalElements,
+                        @JsonProperty("totalPages") int totalPages,
+                        @JsonProperty("last") boolean last,
+                        @JsonProperty("first") boolean first,
+                        @JsonProperty("sorted") boolean sorted) {
+        this.content = content;
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.last = last;
+        this.first = first;
+        this.sorted = sorted;
+    }
+
+    @Builder
+    public PageResponse(Page<T> page) {
+        this(page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast(),
+                page.isFirst(),
+                page.getSort().isSorted()
+        );
+    }
+}

--- a/src/main/java/org/example/tablenow/global/rabbitmq/config/RabbitConfig.java
+++ b/src/main/java/org/example/tablenow/global/rabbitmq/config/RabbitConfig.java
@@ -84,6 +84,36 @@ public class RabbitConfig {
                 .with(RESERVATION_REMINDER_SEND_ROUTING_KEY);
     }
 
+    // 가게 데이터 변경 (Create/Update/Delete) Queue, Exchange, Binding
+    @Bean
+    public Queue storeCreateQueue() {
+        return new Queue(STORE_CREATE_QUEUE, true);
+    }
+    @Bean
+    public Queue storeUpdateQueue() {
+        return new Queue(STORE_UPDATE_QUEUE, true);
+    }
+    @Bean
+    public Queue storeDeleteQueue() {
+        return new Queue(STORE_DELETE_QUEUE, true);
+    }
+    @Bean
+    public DirectExchange storeExchange(){
+        return new DirectExchange(STORE_EXCHANGE);
+    }
+    @Bean
+    public Binding storeCreateBinding(){
+        return BindingBuilder.bind(storeCreateQueue()).to(storeExchange()).with(STORE_CREATE);
+    }
+    @Bean
+    public Binding storeUpdateBinding(){
+        return BindingBuilder.bind(storeUpdateQueue()).to(storeExchange()).with(STORE_UPDATE);
+    }
+    @Bean
+    public Binding storeDeleteBinding(){
+        return BindingBuilder.bind(storeDeleteQueue()).to(storeExchange()).with(STORE_DELETE);
+    }
+
     // 공통 설정
     @Bean
     public MessageConverter jsonMessageConverter() {

--- a/src/main/java/org/example/tablenow/global/rabbitmq/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/rabbitmq/constant/RabbitConstant.java
@@ -15,4 +15,12 @@ public class RabbitConstant {
     public static final String RESERVATION_REMINDER_SEND_EXCHANGE = "reservation.reminder.send.exchange";
     public static final String RESERVATION_REMINDER_SEND_QUEUE = "reservation.reminder.send.queue";
     public static final String RESERVATION_REMINDER_SEND_ROUTING_KEY = "reservation.reminder.send.key";
+
+    public static final String STORE_EXCHANGE = "store.exchange";
+    public static final String STORE_CREATE = "store.create";
+    public static final String STORE_UPDATE = "store.update";
+    public static final String STORE_DELETE = "store.delete";
+    public static final String STORE_CREATE_QUEUE = "store.create.queue";
+    public static final String STORE_UPDATE_QUEUE = "store.update.queue";
+    public static final String STORE_DELETE_QUEUE = "store.delete.queue";
 }

--- a/src/main/resources/elastic/store-setting.json
+++ b/src/main/resources/elastic/store-setting.json
@@ -1,14 +1,10 @@
 {
   "analysis": {
     "filter": {
-      "nori_readingform": {
-        "type": "nori_readingform"
-      },
       "nori_part_of_speech": {
         "type": "nori_part_of_speech",
         "stoptags": [
-          "EP", "EF", "EC", "ETN", "ETM",
-          "IC",
+          "EP", "EF",
           "JKS", "JKC", "JKO", "JKB", "JKG", "JX", "JC",
           "SP", "SSC", "SSO", "SC"
         ]
@@ -20,28 +16,18 @@
         "generate_word_parts": true,
         "generate_number_parts": true,
         "catenate_all": false
-      },
-      "custom_snowball_filter": {
-        "type": "snowball",
-        "language": "English"
       }
     },
     "analyzer": {
       "korean_search": {
         "type": "custom",
         "tokenizer": "nori_tokenizer",
-        "filter": ["nori_part_of_speech", "nori_readingform", "lowercase"]
+        "filter": ["nori_part_of_speech", "lowercase"]
       },
       "mixed_analyzer": {
         "type": "custom",
         "tokenizer": "nori_tokenizer",
-        "filter": ["nori_part_of_speech", "nori_readingform", "word_delimiter", "lowercase"]
-      }
-    },
-    "normalizer": {
-      "lowercase_normalizer": {
-        "type": "custom",
-        "filter": ["lowercase"]
+        "filter": ["nori_part_of_speech", "word_delimiter", "lowercase"]
       }
     }
   }

--- a/src/test/java/org/example/tablenow/domain/store/service/StoreCreateTest.java
+++ b/src/test/java/org/example/tablenow/domain/store/service/StoreCreateTest.java
@@ -1,7 +1,6 @@
 package org.example.tablenow.domain.store.service;
 
 import org.example.tablenow.domain.store.dto.request.StoreCreateRequestDto;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,13 +21,13 @@ public class StoreCreateTest {
 
     static final int TOTAL_STORES = 100_000;
 
-    @Test
+    //@Test
     void 테스트_가게_생성() {
         List<StoreCreateRequestDto> requestDtoList = new ArrayList<>();
 
         for (int i = 0; i < TOTAL_STORES; i++) {
             LocalTime start = LocalTime.of(6, 00).plusHours(random.nextInt(8));
-            LocalTime end = start.plusHours(random.nextInt(8,10));
+            LocalTime end = start.plusHours(random.nextInt(8, 10));
             Long categoryId = Long.valueOf(random.nextInt(1, 16));
             Integer capacity = random.nextInt(1, 50) * 10;
             Integer deposit = random.nextInt(1, 9) * 10000;

--- a/src/test/java/org/example/tablenow/domain/store/service/StoreSearchServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/store/service/StoreSearchServiceTest.java
@@ -1,13 +1,18 @@
 package org.example.tablenow.domain.store.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.tablenow.domain.category.entity.Category;
 import org.example.tablenow.domain.store.dto.response.StoreDocumentResponseDto;
 import org.example.tablenow.domain.store.entity.StoreDocument;
 import org.example.tablenow.domain.store.enums.StoreSortField;
 import org.example.tablenow.domain.store.repository.StoreElasticRepository;
+import org.example.tablenow.domain.store.util.StoreKeyGenerator;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.global.dto.AuthUser;
+import org.example.tablenow.global.dto.PageResponse;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
 import org.junit.jupiter.api.Nested;
@@ -17,12 +22,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
+import static org.example.tablenow.domain.store.util.StoreConstant.STORE_CACHE_KEY;
+import static org.example.tablenow.domain.store.util.StoreConstant.STORE_SEARCH_KEY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -35,11 +47,26 @@ public class StoreSearchServiceTest {
     @Mock
     private StoreElasticRepository storeElasticRepository;
     @Mock
-    private RedisTemplate<Object, Object> redisTemplate;
-    @Mock
-    private ValueOperations<Object, Object> valueOperations;
+    private TextAnalyzerService textAnalyzerService;
     @Mock
     private StoreService storeService;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    @Mock
+    private SetOperations<String, String> setOperations;
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private RedisConnectionFactory redisConnectionFactory;
+    @Mock
+    private RedisConnection redisConnection;
+    @Mock
+    private Cursor<byte[]> cursor;
+
     @InjectMocks
     private StoreSearchService storeSearchService;
 
@@ -111,15 +138,19 @@ public class StoreSearchServiceTest {
         }
 
         @Test
-        void 가게_검색_cache_hit_시_Redis_조회() {
+        void 가게_검색_cache_hit_시_Redis_캐시값을_파싱하여_반환_성공() throws JsonProcessingException {
             // given
-            given(redisTemplate.hasKey(anyString())).willReturn(true);
-            Page<StoreDocumentResponseDto> result = new PageImpl<>(List.of(StoreDocumentResponseDto.fromStoreDocument(storeDocument)));
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
-            given(valueOperations.get(anyString())).willReturn(result);
+            PageResponse<StoreDocumentResponseDto> expectedResponse = new PageResponse<>(new PageImpl<>(List.of(StoreDocumentResponseDto.fromStoreDocument(storeDocument))));
+            // template.opsForValue().get(key) 결과
+            String cachedJson = "{\"content\":[{\"storeId\":1,\"name\":\"맛있는 가게\",\"categoryId\":1,\"categoryName\":\"한식\",\"imageUrl\":null,\"startTime\":\"09:00\",\"endTime\":\"21:30\",\"rating\":4.5,\"ratingCount\":100}],\"totalElements\":1}";
+
+            given(stringRedisTemplate.hasKey(anyString())).willReturn(true);
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(anyString())).willReturn(cachedJson);
+            given(objectMapper.readValue(anyString(), any(JavaType.class))).willReturn(expectedResponse);
 
             // when
-            Page<StoreDocumentResponseDto> response = storeSearchService.getStoresV3(authUser, 1, 10, sortField, sortOrder, null, null);
+            PageResponse<StoreDocumentResponseDto> response = storeSearchService.getStoresV3(authUser, 1, 10, sortField, sortOrder, null, null);
 
             // then
             assertAll(
@@ -131,38 +162,149 @@ public class StoreSearchServiceTest {
         @Test
         void 가게_검색_cache_miss_시_elastic_search_조회_결과_없음() {
             // given
-            given(redisTemplate.hasKey(anyString())).willReturn(false);
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(stringRedisTemplate.hasKey(anyString())).willReturn(false);
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
 
             Page<StoreDocument> result = new PageImpl<>(Collections.emptyList());
             given(storeElasticRepository.searchByKeywordAndCategoryId(anyString(), anyLong(), any(Pageable.class))).willReturn(result);
 
             // when
-            Page<StoreDocumentResponseDto> response = storeSearchService.getStoresV3(authUser, 1, 10, sortField, sortOrder, 1L, "test");
+            PageResponse<StoreDocumentResponseDto> response = storeSearchService.getStoresV3(authUser, 1, 10, sortField, sortOrder, 1L, "test");
 
             // then
             assertNotNull(response);
-            verify(redisTemplate.opsForValue(), never()).set(anyString(), any());
+            verify(stringRedisTemplate.opsForValue(), never()).set(anyString(), any());
         }
 
         @Test
         void 가게_검색_cache_miss_시_elastic_search_조회_및_캐시_저장() {
             // given
-            given(redisTemplate.hasKey(anyString())).willReturn(false);
-            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(stringRedisTemplate.hasKey(anyString())).willReturn(false);
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
 
             Page<StoreDocument> result = new PageImpl<>(List.of(storeDocument));
             given(storeElasticRepository.searchByKeywordAndCategoryId(null, null, pageable)).willReturn(result);
 
             // when
-            Page<StoreDocumentResponseDto> response = storeSearchService.getStoresV3(authUser, 1, 10, sortField, sortOrder, null, null);
+            PageResponse<StoreDocumentResponseDto> response = storeSearchService.getStoresV3(authUser, 1, 10, sortField, sortOrder, null, null);
 
             // then
             assertAll(
                     () -> assertNotNull(response),
                     () -> assertEquals(response.getContent().get(0).getStoreId(), storeId)
             );
-            verify(redisTemplate.opsForValue()).set(anyString(), any());
+            verify(stringRedisTemplate.opsForValue()).set(anyString(), isNull(), anyLong(), any(TimeUnit.class));
+            verify(stringRedisTemplate.opsForSet()).add(anyString(), anyString());
+            verify(stringRedisTemplate).expire(anyString(), anyLong(), any(TimeUnit.class));
         }
+    }
+
+    @Nested
+    class 가게_등록_시_캐시_무효화 {
+        @Test
+        void 가게명_기준_예상_검색어_호출_실패_삭제_키_없음() {
+            // given
+            Set<String> analyzeResult = new HashSet<>();
+            given(textAnalyzerService.analyzeText(anyString(), anyString(), anyString())).willReturn(analyzeResult);
+            given(stringRedisTemplate.getConnectionFactory()).willReturn(redisConnectionFactory);
+
+            // when
+            storeSearchService.invalidateCacheOnNewStore(storeDocument);
+
+            // then
+            verify(stringRedisTemplate).delete(Collections.emptySet());
+        }
+
+        @Test
+        void 가게명_기준_예상_검색어_호출_키_삭제_성공() {
+            // given
+            Set<String> analyzeResult = Set.of("맛있", "는");
+            String key1 = STORE_SEARCH_KEY + StoreKeyGenerator.generateStoreListKey(1, 10, "ratingCount", "desc", null, "맛있");
+            String key2 = STORE_SEARCH_KEY + StoreKeyGenerator.generateStoreListKey(1, 10, "ratingCount", "desc", null, "는");
+
+            String serializedKey1 = new StringRedisSerializer().deserialize(key1.getBytes());
+            String serializedKey2 = new StringRedisSerializer().deserialize(key2.getBytes());
+            Set<String> scanResult = Set.of(serializedKey1, serializedKey2);
+
+            given(textAnalyzerService.analyzeText(anyString(), anyString(), anyString())).willReturn(analyzeResult);
+
+            given(stringRedisTemplate.getConnectionFactory()).willReturn(redisConnectionFactory);
+            given(redisConnectionFactory.getConnection()).willReturn(redisConnection);
+            given(redisConnection.scan(any(ScanOptions.class))).willReturn(cursor);
+            given(cursor.hasNext()).willReturn(true, true, false);
+            given(cursor.next()).willReturn(key1.getBytes(), key2.getBytes());
+
+            // when
+            storeSearchService.invalidateCacheOnNewStore(storeDocument);
+
+            // then
+            verify(stringRedisTemplate).delete(scanResult);
+        }
+
+        @Test
+        void 카테고리_ID_기준_키_삭제_성공() {
+            // given
+            String key1 = STORE_SEARCH_KEY + StoreKeyGenerator.generateStoreListKey(1, 10, "ratingCount", "desc", 1L, null);
+            String key2 = STORE_SEARCH_KEY + StoreKeyGenerator.generateStoreListKey(1, 10, "rating", "desc", 1L, null);
+
+            String serializedKey1 = new StringRedisSerializer().deserialize(key1.getBytes());
+            String serializedKey2 = new StringRedisSerializer().deserialize(key2.getBytes());
+            Set<String> scanResult = Set.of(serializedKey1, serializedKey2);
+
+            given(textAnalyzerService.analyzeText(anyString(), anyString(), anyString())).willReturn(Collections.emptySet());
+
+            given(stringRedisTemplate.getConnectionFactory()).willReturn(redisConnectionFactory);
+            given(redisConnectionFactory.getConnection()).willReturn(redisConnection);
+            given(redisConnection.scan(any(ScanOptions.class))).willReturn(cursor);
+            given(cursor.hasNext()).willReturn(true, true, false);
+            given(cursor.next()).willReturn(key1.getBytes(), key2.getBytes());
+
+            // when
+            storeSearchService.invalidateCacheOnNewStore(storeDocument);
+
+            // then
+            verify(stringRedisTemplate).delete(scanResult);
+        }
+    }
+
+    @Nested
+    class 가게_수정_또는_삭제_시_캐시_무효화 {
+        String invertedIndexKey = STORE_CACHE_KEY + storeId;
+
+        @Test
+        void 역인덱스_캐시_키가_없을_경우_무효화_작업_스킵() {
+            // given
+            Set<String> cacheResult = new HashSet<>();
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members(anyString())).willReturn(cacheResult);
+
+            // when
+            storeSearchService.invalidateStoreCacheByKey(storeId);
+
+            // then
+            verify(stringRedisTemplate, never()).delete(cacheResult);
+            verify(stringRedisTemplate, never()).delete(invertedIndexKey);
+        }
+
+        @Test
+        void 역인덱스_캐시_키_조회_캐시_무효화_및_역인덱스_삭제() {
+            // given
+            String cachedKey = "store:search:page=1:size=10:sort=rating:direction=desc:categoryId=1:keyword=";
+
+            Set<String> cacheResult = Set.of(cachedKey);
+
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members(anyString())).willReturn(cacheResult);
+
+            // when
+            storeSearchService.invalidateStoreCacheByKey(storeId);
+
+            // then
+            verify(stringRedisTemplate).delete(cacheResult);
+            verify(stringRedisTemplate).delete(invertedIndexKey);
+        }
+
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #160 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
> 데이터 변경 시점 (DB Create/Update/Delete 발생 시), RabbitMQ를 통해 ElasticSearch 와 Redis 캐시에 변경 사항 반영 → 시스템 데이터 정합성 유지

- [X] 데이터 변경 시 MQ 메시지 전송
- [X] MQ Consumer 구성 (Redis 캐시, ES 인덱스 동기화)
- [X] 가게 검색 테스트코드 수정

> ElasticSearch 의 store-setting.json 수정 (미사용 필터, analyzer 삭제)

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- `역인덱스`: 불필요한 캐시 삭제 없이 필요한 부분만 삭제
- [데이터 변경 시 Redis + ES 반영](https://www.notion.so/teamsparta/Redis-ES-1de2dc3ef5148013b614d5b7611ac05b)
