### PR TITLE
[test] 예약 리마인드 알림 관련 테스트 코드 작성

### DIFF
--- a/src/test/java/org/example/tablenow/domain/reservation/ReminderSchedulerTest.java
+++ b/src/test/java/org/example/tablenow/domain/reservation/ReminderSchedulerTest.java
@@ -1,0 +1,131 @@
+package org.example.tablenow.domain.reservation;
+
+import org.example.tablenow.domain.reservation.entity.Reservation;
+import org.example.tablenow.domain.reservation.entity.ReservationStatus;
+import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
+import org.example.tablenow.domain.reservation.message.producer.ReminderSendProducer;
+import org.example.tablenow.domain.reservation.service.ReminderScheduler;
+import org.example.tablenow.domain.reservation.service.ReservationService;
+import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.domain.user.enums.UserRole;
+import org.example.tablenow.global.dto.AuthUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ReminderSchedulerTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
+    @Mock
+    private ReminderSendProducer sendProducer;
+
+    @Mock
+    private ReservationService reservationService;
+
+    @InjectMocks
+    private ReminderScheduler reminderScheduler;
+
+    Long userId = 1L;
+    Long storeId = 10L;
+    AuthUser authUser = new AuthUser(userId, "user@test.com", UserRole.ROLE_USER, "일반회원");
+    User user = User.fromAuthUser(authUser);
+
+    Store store = Store.builder()
+            .id(storeId)
+            .startTime(LocalTime.of(9, 0))
+            .endTime(LocalTime.of(22, 0))
+            .capacity(20)
+            .build();
+
+    LocalDateTime reservedAt = LocalDateTime.of(2025, 4, 10, 10, 0);
+
+    Reservation reservation;
+
+    @BeforeEach
+    void setUp() {
+        reservation = createReservation(1L, reservedAt, ReservationStatus.RESERVED);
+        given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+    }
+
+    private Reservation createReservation(Long id, LocalDateTime time, ReservationStatus status) {
+        Reservation reservation = Reservation.builder()
+                .id(id)
+                .user(user)
+                .store(store)
+                .reservedAt(time)
+                .build();
+        ReflectionTestUtils.setField(reservation, "status", status);
+        return reservation;
+    }
+
+    @Nested
+    class 스케줄러_실행 {
+        @Test
+        void 알림_도래_예약이_있으면_메시지_발행됨() {
+            // given
+            String reservationId = "1";
+            Set<String> due = Set.of(reservationId);
+
+            given(zSetOperations.rangeByScore(anyString(), anyDouble(), anyDouble())).willReturn(due);
+            given(reservationService.getReservationWithStore(1L)).willReturn(reservation);
+
+            // when
+            reminderScheduler.pollAndSend();
+
+            // then
+            verify(sendProducer).send(any(ReminderMessage.class));
+            verify(redisTemplate.opsForZSet()).remove("reminder:zset", reservationId);
+        }
+
+        @Test
+        void 도래_알림이_비어있으면_아무_작업도_하지_않음() {
+            // given
+            given(zSetOperations.rangeByScore(anyString(), anyDouble(), anyDouble())).willReturn(Collections.emptySet());
+
+            // when
+            reminderScheduler.pollAndSend();
+
+            // then
+            verify(sendProducer, never()).send(any());
+            verify(zSetOperations, never()).remove(anyString(), any());
+        }
+
+        @Test
+        void 도래_알림이_null이면_아무_작업도_하지_않음() {
+            // given
+            given(zSetOperations.rangeByScore(anyString(), anyDouble(), anyDouble())).willReturn(null);
+
+            // when
+            reminderScheduler.pollAndSend();
+
+            // then
+            verify(sendProducer, never()).send(any());
+            verify(zSetOperations, never()).remove(anyString(), any());
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #176 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 예약 성공 시 `ReminderRegisterProducer`를 통한 MQ 메시지 발행 여부 테스트 추가
- [X] 예약 취소 시 `VacancyProducer`를 통한 MQ 메시지 발행 여부 테스트 추가
- [X] `ReminderScheduler`의 `pollAndSend()`에 대한 단위 테스트 추가
  - [X] Redis ZSET에서 도래 예약 ID 조회
  - [X] `ReservationService`를 통해 예약 정보 조회
  - [X] `ReminderSendProducer`를 통해 MQ 메시지 발행
  - [X] 발송 후 Redis ZSET에서 해당 ID 제거
  - [X] ZSET이 `null` 또는 `empty`일 경우 아무 동작 없이 종료

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
### Consumer 테스트는 작성하지 않은 이유
`@RabbitListener`가 붙은 Consumer 클래스는 Spring 컨테이너에서만 제대로 동작하며, 메시지를 직접 주입하거나 트리거할 수 있는 환경이 필요합니다. 따라서 해당 로직은 **단위 테스트보다 통합 테스트 환경에서 검증하는 것이 적절**합니다. 또한 현재 Consumer 내부의 핵심 로직들은 대부분 별도의 Service를 호출하거나 DTO를 조립하는 작업이므로, 핵심 서비스의 단위 테스트만으로도 기능 보장이 가능하다고 판단했습니다.

### 스케줄러를 직접 호출하는 방식으로 테스트한 이유
`@Scheduled`는 **Spring 컨텍스트 내에서 스케줄링 스레드에 의해 자동 실행**되므로, 단위 테스트 환경에서는 해당 어노테이션이 동작하지 않습니다. 따라서 `pollAndSend()` 메서드를 **직접 호출하는 방식으로 테스트를 수행**했습니다.
- [@Scheduled 메서드는 왜 직접 호출하여 테스트해야 할까?](https://www.notion.so/teamsparta/Scheduled-1df2dc3ef51480279aeec634e59162a3?pvs=4)

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![스크린샷 2025-04-24 155725](https://github.com/user-attachments/assets/1dd0d97a-2b32-4a1f-b122-cda06303b57b)
