### PR TITLE
[feat] 채팅 가능 여부 확인 및 메시지 목록/읽음 처리 API 구현

### DIFF
--- a/src/main/java/org/example/tablenow/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/tablenow/domain/chat/controller/ChatController.java
@@ -1,0 +1,28 @@
+package org.example.tablenow.domain.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.domain.chat.dto.response.ChatAvailabilityResponse;
+import org.example.tablenow.domain.chat.service.ChatMessageService;
+import org.example.tablenow.global.dto.AuthUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ChatController {
+
+    private final ChatMessageService chatMessageService;
+
+    @GetMapping("/v1/chats/{reservationId}/availability")
+    public ResponseEntity<ChatAvailabilityResponse> checkChatAvailability(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        return ResponseEntity.ok(chatMessageService.isChatAvailable(reservationId, authUser.getId()));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/tablenow/domain/chat/controller/ChatController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.tablenow.domain.chat.dto.response.ChatAvailabilityResponse;
 import org.example.tablenow.domain.chat.dto.response.ChatMessagePageResponse;
 import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
+import org.example.tablenow.domain.chat.dto.response.ChatReadStatusResponse;
 import org.example.tablenow.domain.chat.service.ChatMessageService;
 import org.example.tablenow.global.dto.AuthUser;
 import org.springframework.data.domain.Page;
@@ -12,10 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,5 +38,13 @@ public class ChatController {
     ) {
         Page<ChatMessageResponse> page = chatMessageService.getMessages(reservationId, authUser.getId(), pageable);
         return ResponseEntity.ok(ChatMessagePageResponse.fromChatMessageResponsePage(page));
+    }
+
+    @PatchMapping("/v1/chats/{reservationId}/read")
+    public ResponseEntity<ChatReadStatusResponse> changeReadStatus(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser
+    ) {
+        return ResponseEntity.ok(chatMessageService.changeReadStatus(reservationId, authUser.getId()));
     }
 }

--- a/src/main/java/org/example/tablenow/domain/chat/controller/ChatController.java
+++ b/src/main/java/org/example/tablenow/domain/chat/controller/ChatController.java
@@ -2,8 +2,14 @@ package org.example.tablenow.domain.chat.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.tablenow.domain.chat.dto.response.ChatAvailabilityResponse;
+import org.example.tablenow.domain.chat.dto.response.ChatMessagePageResponse;
+import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
 import org.example.tablenow.domain.chat.service.ChatMessageService;
 import org.example.tablenow.global.dto.AuthUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,5 +30,15 @@ public class ChatController {
             @AuthenticationPrincipal AuthUser authUser
     ) {
         return ResponseEntity.ok(chatMessageService.isChatAvailable(reservationId, authUser.getId()));
+    }
+
+    @GetMapping("/v1/chats/{reservationId}")
+    public ResponseEntity<ChatMessagePageResponse> getChatMessages(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal AuthUser authUser,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<ChatMessageResponse> page = chatMessageService.getMessages(reservationId, authUser.getId(), pageable);
+        return ResponseEntity.ok(ChatMessagePageResponse.fromChatMessageResponsePage(page));
     }
 }

--- a/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatAvailabilityResponse.java
+++ b/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatAvailabilityResponse.java
@@ -1,0 +1,15 @@
+package org.example.tablenow.domain.chat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatAvailabilityResponse {
+    private final Long reservationId;
+    private final Long userId;
+    @JsonProperty("isAvailable")
+    private final boolean available;
+    private final String reason;
+}

--- a/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatMessagePageResponse.java
+++ b/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatMessagePageResponse.java
@@ -1,0 +1,30 @@
+package org.example.tablenow.domain.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatMessagePageResponse {
+
+    private List<ChatMessageResponse> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    public static ChatMessagePageResponse fromChatMessageResponsePage(Page<ChatMessageResponse> page) {
+        return ChatMessagePageResponse.builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,5 +1,7 @@
 package org.example.tablenow.domain.chat.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.tablenow.domain.chat.entity.ChatMessage;
@@ -9,17 +11,25 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ChatMessageResponse {
+    private final Long id;
+    private final Long senderId;
     private final String senderName;
     private final String content;
     private final String imageUrl;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
+    @JsonProperty("isRead")
+    private final boolean read;
 
     public static ChatMessageResponse fromChatMessage(ChatMessage chatMessage) {
         return ChatMessageResponse.builder()
+                .id(chatMessage.getId())
+                .senderId(chatMessage.getSender().getId())
                 .senderName(chatMessage.getSender().getName())
                 .content(chatMessage.getContent())
                 .imageUrl(chatMessage.getImageUrl())
                 .createdAt(chatMessage.getCreatedAt())
+                .read(chatMessage.isRead())
                 .build();
     }
 }

--- a/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatReadStatusResponse.java
+++ b/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatReadStatusResponse.java
@@ -1,0 +1,12 @@
+package org.example.tablenow.domain.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatReadStatusResponse {
+    private final Long reservationId;
+    private final Long userId;
+    private final String message;
+}

--- a/src/main/java/org/example/tablenow/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/example/tablenow/domain/chat/entity/ChatMessage.java
@@ -55,4 +55,8 @@ public class ChatMessage {
         this.isRead = isRead;
         this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
     }
+
+    public void changeToRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/org/example/tablenow/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/example/tablenow/domain/chat/repository/ChatMessageRepository.java
@@ -1,6 +1,8 @@
 package org.example.tablenow.domain.chat.repository;
 
 import org.example.tablenow.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +11,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     // reservationId 기준 가장 최근 메시지 1개 조회
     Optional<ChatMessage> findTop1ByReservationIdOrderByCreatedAtDesc(Long reservationId);
+
+    Page<ChatMessage> findByReservationId(Long reservationId, Pageable pageable);
 }

--- a/src/main/java/org/example/tablenow/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/example/tablenow/domain/chat/repository/ChatMessageRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
@@ -13,4 +14,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     Optional<ChatMessage> findTop1ByReservationIdOrderByCreatedAtDesc(Long reservationId);
 
     Page<ChatMessage> findByReservationId(Long reservationId, Pageable pageable);
+
+    // reservationId 채팅에 대해 보낸 사람이 나(userId)가 아니며, 아직 읽지 않은 메시지들을 조회
+    List<ChatMessage> findByReservationIdAndSenderIdNotAndIsReadFalse(Long reservationId, Long senderId);
 }

--- a/src/main/java/org/example/tablenow/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/example/tablenow/domain/chat/service/ChatMessageService.java
@@ -3,6 +3,7 @@ package org.example.tablenow.domain.chat.service;
 import lombok.RequiredArgsConstructor;
 import org.example.tablenow.domain.chat.dto.request.ChatMessageRequest;
 import org.example.tablenow.domain.chat.dto.response.ChatAvailabilityResponse;
+import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
 import org.example.tablenow.domain.chat.entity.ChatMessage;
 import org.example.tablenow.domain.chat.repository.ChatMessageRepository;
 import org.example.tablenow.domain.reservation.entity.Reservation;
@@ -12,6 +13,8 @@ import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.service.UserService;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +34,8 @@ public class ChatMessageService {
 
     @Transactional
     public ChatMessage saveMessage(ChatMessageRequest request, Long senderId) {
-        ChatParticipants participants = loadAndValidateParticipants(request.getReservationId(), senderId);
+        ChatParticipants participants = loadChatParticipants(request.getReservationId());
+        validateChatParticipant(senderId, participants);
 
         return chatMessageRepository.save(buildChatMessage(
                 request,
@@ -41,11 +45,14 @@ public class ChatMessageService {
         ));
     }
 
+    @Transactional(readOnly = true)
     public ChatAvailabilityResponse isChatAvailable(Long reservationId, Long userId) {
-        ChatParticipants participants = loadAndValidateParticipants(reservationId, userId);
+        ChatParticipants participants = loadChatParticipants(reservationId);
+        validateChatParticipant(userId, participants);
 
         Reservation reservation = reservationService.getReservation(reservationId);
         boolean isAvailable = reservation.getStatus() == ReservationStatus.RESERVED;
+
         return ChatAvailabilityResponse.builder()
                 .reservationId(reservationId)
                 .userId(userId)
@@ -54,32 +61,39 @@ public class ChatMessageService {
                 .build();
     }
 
-    private ChatParticipants loadAndValidateParticipants(Long reservationId, Long userId) {
-        Long ownerId;
-        Long reservationUserId;
+    @Transactional(readOnly = true)
+    public Page<ChatMessageResponse> getMessages(Long reservationId, Long userId, Pageable pageable) {
+        ChatParticipants participants = loadChatParticipants(reservationId);
+        validateChatParticipant(userId, participants);
 
+        Page<ChatMessage> messages = chatMessageRepository.findByReservationId(reservationId, pageable);
+
+        return messages.map(ChatMessageResponse::fromChatMessage);
+    }
+
+    private ChatParticipants loadChatParticipants(Long reservationId) {
         Optional<ChatMessage> lastMessageOpt =
                 chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(reservationId);
-
 
         if (lastMessageOpt.isPresent()) {
             // 채팅한 내역이 있을 경우 chatMessage 정보로 참여자 정보 추출
             ChatMessage lastMessage = lastMessageOpt.get();
-            ownerId = lastMessage.getOwnerId();
-            reservationUserId = lastMessage.getReservationUserId();
+            return new ChatParticipants(
+                    lastMessage.getOwnerId(),
+                    lastMessage.getReservationUserId()
+            );
         } else {
             // 최초 채팅일 경우 reservation 정보로 참여자 정보 추출
             Reservation reservation = reservationService.getReservation(reservationId);
-            ownerId = reservation.getStore().getUser().getId();
-            reservationUserId = reservation.getUser().getId();
+            return new ChatParticipants(
+                    reservation.getStore().getUser().getId(),
+                    reservation.getUser().getId()
+            );
         }
-
-        validateChatParticipant(userId, ownerId, reservationUserId);
-        return new ChatParticipants(ownerId, reservationUserId);
     }
 
-    private void validateChatParticipant(Long senderId, Long ownerId, Long reservationUserId) {
-        if (!senderId.equals(ownerId) && !senderId.equals(reservationUserId)) {
+    private void validateChatParticipant(Long userId, ChatParticipants participants) {
+        if (!userId.equals(participants.ownerId()) && !userId.equals(participants.reservationUserId())) {
             throw new HandledException(ErrorCode.INVALID_CHAT_PARTICIPANT);
         }
     }

--- a/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
@@ -28,7 +28,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     /* 클라이언트가 메시지를 보낼 때의 prefix 설정 */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setApplicationDestinationPrefixes(WebSocketConstants.APP_DEST_PREFIX);
-        registry.enableSimpleBroker(WebSocketConstants.TOPIC_PREFIX);
+        registry.setApplicationDestinationPrefixes(WebSocketConstants.APP_DEST_PREFIX); // 클라이언트가 보낼 때 prefix
+        registry.enableSimpleBroker(WebSocketConstants.TOPIC_PREFIX);                   // 서버가 브로드캐스트할 때 prefix
     }
 }

--- a/src/main/java/org/example/tablenow/global/constant/WebSocketConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/WebSocketConstants.java
@@ -2,9 +2,19 @@ package org.example.tablenow.global.constant;
 
 public final class WebSocketConstants {
 
+    // WebSocket 연결 시 사용할 엔드포인트 (SockJS에서 접속 경로로 사용됨)
     public static final String ENDPOINT_CHAT = "/ws/chat";
+
+    // 클라이언트가 메시지를 보낼 때 사용하는 prefix
+    // ex) stompClient.send("/app/chat/message", ...)
     public static final String APP_DEST_PREFIX = "/app";
+
+    // 서버가 메시지를 브로드캐스트할 때 사용하는 prefix
+    // ex) messagingTemplate.convertAndSend("/topic/...")
     public static final String TOPIC_PREFIX = "/topic";
+
+    // 채팅방 메시지를 브로드캐스트할 때 사용하는 prefix
+    // ex) /topic/chat/{reservationId}
     public static final String TOPIC_CHAT_PREFIX = "/topic/chat/";
 
     private WebSocketConstants() {

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -113,7 +113,7 @@ public enum ErrorCode {
     INVALID_SETTLEMENT_STATUS(HttpStatus.BAD_REQUEST, "정산 완료 상태에서만 취소할 수 있습니다."),
 
     // CHAT
-    UNAUTHORIZED_CHAT_SENDER(HttpStatus.FORBIDDEN, "채팅에 참여할 수 있는 권한이 없습니다.");
+    INVALID_CHAT_PARTICIPANT(HttpStatus.FORBIDDEN, "채팅에 참여할 수 있는 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #168

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [x] `GET` `/api/v1/chats/{reservationId}`: 메시지 목록 조회
  - @PageableDefault로 page=0, size=20 자동 매핑
- [x] `PATCH` `/api/v1/chats/{reservationId}/read`: 사용자 기준 읽음 처리
  - 채팅방(reservationId)에 대해 보낸 사람이 본인이 아닌 경우에 읽지 않은 메시지들을 읽음 처리
- [x] `GET` `/api/v1/chats/{reservationId}/availability`: 채팅 가능 여부 확인
  - WebSocket 연결 전 상태를 확인하는 용도
  - 예약 상태가 RESERVED일 때만 채팅 가능
    - reason: available 값에 대한 이유를 상태값(enum)으로 반환
      - true일 경우 RESERVED
      - false일 경우 CANCELED, COMPLETED

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- WebSocket용 컨트롤러 ChatMessageController와 분리된 REST API용 컨트롤러 ChatController 생성
![image](https://github.com/user-attachments/assets/18a26fa4-2982-440f-9e26-69f5a5170960)
- 메시지 목록 조회 시 Page<T> 응답을 DTO(ChatMessagePageResponse)로 래핑
  - Spring 경고 발생 방지 ("Serializing PageImpl instances as-is is not supported...")

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
- 채팅 가능 여부 확인
![image](https://github.com/user-attachments/assets/9b8c43bc-c7ef-4dad-979f-173ad9493879)

- 메시지 목록 조회
![image](https://github.com/user-attachments/assets/fad471f3-e9cc-4188-8e41-28c92c91f3a8)

- 사용자 기준 읽음 처리
![image](https://github.com/user-attachments/assets/20ca8d12-173f-4ab9-86d8-a9bcf414b262)
![image](https://github.com/user-attachments/assets/f21184d0-582b-4582-ac06-8691201cfffd)

