### PR TITLE
[refactor] rabbitMQ 패키지 구조 변경

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenConsumer.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.EVENT_OPEN_QUEUE;
+import static org.example.tablenow.global.constant.RabbitConstant.EVENT_OPEN_QUEUE;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/domain/event/message/producer/EventOpenProducer.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/producer/EventOpenProducer.java
@@ -2,7 +2,7 @@ package org.example.tablenow.domain.event.message.producer;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.tablenow.global.rabbitmq.constant.RabbitConstant;
+import org.example.tablenow.global.constant.RabbitConstant;
 import org.example.tablenow.domain.event.message.dto.EventOpenMessage;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.ZoneOffset;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESERVATION_REMINDER_REGISTER_QUEUE;
+import static org.example.tablenow.global.constant.RabbitConstant.RESERVATION_REMINDER_REGISTER_QUEUE;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
@@ -11,7 +11,7 @@ import org.example.tablenow.domain.user.service.UserService;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESERVATION_REMINDER_SEND_QUEUE;
+import static org.example.tablenow.global.constant.RabbitConstant.RESERVATION_REMINDER_SEND_QUEUE;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
@@ -6,7 +6,7 @@ import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+import static org.example.tablenow.global.constant.RabbitConstant.*;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
@@ -6,7 +6,7 @@ import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+import static org.example.tablenow.global.constant.RabbitConstant.*;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/domain/store/message/consumer/StoreConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/consumer/StoreConsumer.java
@@ -9,7 +9,7 @@ import org.example.tablenow.domain.store.service.StoreSearchService;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+import static org.example.tablenow.global.constant.RabbitConstant.*;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/domain/store/message/producer/StoreProducer.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/producer/StoreProducer.java
@@ -7,7 +7,7 @@ import org.example.tablenow.domain.store.message.dto.StoreEventDto;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+import static org.example.tablenow.global.constant.RabbitConstant.*;
 
 
 @Slf4j

--- a/src/main/java/org/example/tablenow/global/config/RabbitConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/RabbitConfig.java
@@ -1,4 +1,4 @@
-package org.example.tablenow.global.rabbitmq.config;
+package org.example.tablenow.global.config;
 
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -8,7 +8,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.*;
+import static org.example.tablenow.global.constant.RabbitConstant.*;
 
 @Configuration
 public class RabbitConfig {

--- a/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
@@ -1,4 +1,4 @@
-package org.example.tablenow.global.rabbitmq.constant;
+package org.example.tablenow.global.constant;
 
 public class RabbitConstant {
     public static final String VACANCY_EXCHANGE = "vacancy.direct";

--- a/src/main/java/org/example/tablenow/global/rabbitmq/vacancy/consumer/VacancyConsumer.java
+++ b/src/main/java/org/example/tablenow/global/rabbitmq/vacancy/consumer/VacancyConsumer.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.VACANCY_QUEUE;
+import static org.example.tablenow.global.constant.RabbitConstant.VACANCY_QUEUE;
 
 @Slf4j
 @Component

--- a/src/main/java/org/example/tablenow/global/rabbitmq/vacancy/producer/VacancyProducer.java
+++ b/src/main/java/org/example/tablenow/global/rabbitmq/vacancy/producer/VacancyProducer.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.VACANCY_EXCHANGE;
-import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.VACANCY_ROUTING_KEY;
+import static org.example.tablenow.global.constant.RabbitConstant.VACANCY_EXCHANGE;
+import static org.example.tablenow.global.constant.RabbitConstant.VACANCY_ROUTING_KEY;
 
 @Slf4j
 @Component


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #162

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
도메인 별 message 패키지를 생성하고 하위로 consumer, dto, producer
RabbitConfig는 기존 config로, RabbitConstant는 constant로 이전

- [X] RabbitConfig 패키지 이동
- [X] RabbitConstant 패키지 이동

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
RabbitMQ 패키지 이동으로 아래 소스에 영향이 있습니다.

**event/message**
- `EventOpenConsumer` / `EventOpenProducer`

**reservation/message**
- `ReminderRegisterConsumer` / `ReminderRegisterProducer`
- `ReminderSendConsumer` / `ReminderSendProducer`

store/message
- `StoreConsumer` / `StoreProducer`

---
💡 빈자리(Vacancy) 패키지의 이동 시 #182 와 충돌이 예상되어 도메인 패키지로 이동하지 않았습니다.
- VacancyConsumer / VacancyEventDto / VacancyProducer
→ 패키지 이동은 해당 PR 머지 후 직접 이동 부탁드립니다! 

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![스크린샷 2025-04-25 오전 9 35 01](https://github.com/user-attachments/assets/b6f0fe94-5375-4102-8f64-f4f5f4835583)
