### PR TITLE
[refactor] 예약 및 이벤트 Redis Key 상수 클래스로 분리

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/service/EventJoinExecutor.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventJoinExecutor.java
@@ -15,6 +15,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.example.tablenow.global.constant.RedisKeyConstants.EVENT_JOIN_PREFIX;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -23,7 +25,6 @@ public class EventJoinExecutor {
     private final StringRedisTemplate redisTemplate;
     private final EventRepository eventRepository;
     private final EventJoinRepository eventJoinRepository;
-    private static final String EVENT_JOIN_PREFIX = "event:join:";
 
     @Transactional
     public EventJoinResponseDto execute(Long eventId, AuthUser authUser) {

--- a/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static org.example.tablenow.global.constant.RedisKeyConstants.EVENT_LOCK_KEY_PREFIX;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -26,8 +28,6 @@ public class EventJoinService {
     private final EventJoinRepository eventJoinRepository;
     private final EventRepository eventRepository;
     private final EventJoinExecutor eventJoinExecutor;
-
-    private static final String EVENT_LOCK_KEY_PREFIX = "lock:event";
 
     @Transactional
     public EventJoinResponseDto joinEventWithoutLock(Long eventId, AuthUser authUser) {

--- a/src/main/java/org/example/tablenow/domain/event/service/EventService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventService.java
@@ -27,6 +27,9 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Set;
 
+import static org.example.tablenow.global.constant.RedisKeyConstants.EVENT_JOIN_PREFIX;
+import static org.example.tablenow.global.constant.RedisKeyConstants.EVENT_OPEN_KEY;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,9 +39,6 @@ public class EventService {
     private final StoreService storeService;
     private final StringRedisTemplate redisTemplate;
     private final EventOpenProducer eventOpenProducer;
-
-    private static final String EVENT_JOIN_PREFIX = "event:join:";
-    public static final String EVENT_OPEN_KEY = "event:open";
 
     @Transactional
     public EventResponseDto createEvent(EventRequestDto request) {

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.ZoneOffset;
 
+import static org.example.tablenow.global.constant.RedisKeyConstants.REMINDER_ZSET_KEY;
 import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESERVATION_REMINDER_REGISTER_QUEUE;
 
 @Slf4j
@@ -16,7 +17,6 @@ import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESER
 @RequiredArgsConstructor
 public class ReminderRegisterConsumer {
     private final StringRedisTemplate redisTemplate;
-    private static final String REMINDER_ZSET_KEY = "reminder:zset";
 
     @RabbitListener(queues = RESERVATION_REMINDER_REGISTER_QUEUE)
     public void handleReminderRegister(ReminderMessage message) {

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
@@ -18,9 +18,9 @@ import static org.example.tablenow.global.rabbitmq.constant.RabbitConstant.RESER
 @RequiredArgsConstructor
 public class ReminderSendConsumer {
     private final NotificationService notificationService;
+    private final UserService userService;
 
     private static final String RESERVATION_REMINDER_MSG_TEMPLATE = "%s에 %s 예약이 있습니다!";
-    private final UserService userService;
 
     @RabbitListener(queues = RESERVATION_REMINDER_SEND_QUEUE)
     public void consume(ReminderMessage message) {

--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
@@ -23,12 +23,16 @@ import org.example.tablenow.global.rabbitmq.vacancy.producer.VacancyProducer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+
+import static org.example.tablenow.global.constant.RedisKeyConstants.REMINDER_ZSET_KEY;
+import static org.example.tablenow.global.constant.RedisKeyConstants.RESERVATION_LOCK_KEY_PREFIX;
 
 @Slf4j
 @Service
@@ -39,8 +43,7 @@ public class ReservationService {
     private final StoreService storeService;
     private final VacancyProducer vacancyProducer;
     private final ReminderRegisterProducer reminderRegisterProducer;
-
-    private static final String RESERVATION_LOCK_KEY_PREFIX = "lock:reservation";
+    private final StringRedisTemplate redisTemplate;
 
     @Transactional
     public ReservationResponseDto makeReservation(AuthUser authUser, ReservationRequestDto request) {
@@ -146,7 +149,7 @@ public class ReservationService {
             reservation.getStore().getId(),
             reservation.getReservedAt().toLocalDate()
         );
-
+        redisTemplate.opsForZSet().remove(REMINDER_ZSET_KEY, id);
 
         return ReservationStatusResponseDto.fromReservation(reservation);
     }

--- a/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
@@ -1,0 +1,14 @@
+package org.example.tablenow.global.constant;
+
+public class RedisKeyConstants {
+    // 예약
+    public static final String REMINDER_ZSET_KEY = "reminder:zset";
+    public static final String RESERVATION_LOCK_KEY_PREFIX = "lock:reservation";
+
+    // 이벤트
+    public static final String EVENT_JOIN_PREFIX = "event:join";
+    public static final String EVENT_LOCK_KEY_PREFIX = "lock:event";
+    public static final String EVENT_OPEN_KEY = "event:open";
+
+    private RedisKeyConstants() {}
+}

--- a/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
@@ -1,14 +1,19 @@
 package org.example.tablenow.global.constant;
 
 public class RedisKeyConstants {
-    // 예약
-    public static final String REMINDER_ZSET_KEY = "reminder:zset";
-    public static final String RESERVATION_LOCK_KEY_PREFIX = "lock:reservation";
+    // 공통 prefix
+    public static final String RESERVATION_PREFIX = "reservation:";
+    public static final String EVENT_PREFIX = "event:";
+    public static final String LOCK_PREFIX = "lock:";
 
-    // 이벤트
-    public static final String EVENT_JOIN_PREFIX = "event:join";
-    public static final String EVENT_LOCK_KEY_PREFIX = "lock:event";
-    public static final String EVENT_OPEN_KEY = "event:open";
+    // 예약 관련
+    public static final String REMINDER_ZSET_KEY = RESERVATION_PREFIX + "reminder:zset";
+    public static final String RESERVATION_LOCK_KEY_PREFIX = LOCK_PREFIX + "reservation";
+
+    // 이벤트 관련
+    public static final String EVENT_JOIN_PREFIX = EVENT_PREFIX + "join";
+    public static final String EVENT_LOCK_KEY_PREFIX = LOCK_PREFIX + "event";
+    public static final String EVENT_OPEN_KEY = EVENT_PREFIX + "open";
 
     private RedisKeyConstants() {}
 }


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #186 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] `RedisKeyConstants` 클래스 생성
- [X] 예약/이벤트 Redis Key `RedisKeyConstants` 클래스로 이동
- [X] 각 클래스에서 중복 사용되던 상수 제거

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- 다른 도메인의 Redis Key도 해당 파일에서 관리하면 좋을 것 같습니다.
