### PR TITLE
fix(waitlist): 날짜별 대기 등록 중복 허용을 위한 중복 체크 조건 수정 (#190)

### DIFF
--- a/src/main/java/org/example/tablenow/domain/waitlist/repository/WaitlistRepository.java
+++ b/src/main/java/org/example/tablenow/domain/waitlist/repository/WaitlistRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface WaitlistRepository extends JpaRepository<Waitlist, Long> {
     // 한 유저가 동일한 가게 중복 등록 방지
-    boolean existsByUserAndStoreAndIsNotifiedFalse(User user, Store store);
+    boolean existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(User user, Store store, LocalDate waitDate);
 
     // 해당 가게에서 대기 인원 수 조회 (알림 미수신만)
     long countByStoreAndWaitDateAndIsNotifiedFalse(Store store, LocalDate waitDate);

--- a/src/main/java/org/example/tablenow/domain/waitlist/service/WaitlistService.java
+++ b/src/main/java/org/example/tablenow/domain/waitlist/service/WaitlistService.java
@@ -47,7 +47,7 @@ public class WaitlistService {
         validateNoVacancy(findStore, requestDto.getWaitDate());
 
         // 해당 가게에 유저가 이미 대기 중인지 확인
-        if (waitlistRepository.existsByUserAndStoreAndIsNotifiedFalse(findUser, findStore)) {
+        if (waitlistRepository.existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(findUser, findStore, requestDto.getWaitDate())) {
             throw new HandledException(ErrorCode.WAITLIST_ALREADY_REGISTERED);
         }
 
@@ -88,7 +88,7 @@ public class WaitlistService {
             validateNoVacancy(findStore, requestDto.getWaitDate());
 
             // 해당 가게에 유저가 이미 대기 중인지 확인
-            if (waitlistRepository.existsByUserAndStoreAndIsNotifiedFalse(findUser, findStore)) {
+            if (waitlistRepository.existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(findUser, findStore, requestDto.getWaitDate())) {
                 throw new HandledException(ErrorCode.WAITLIST_ALREADY_REGISTERED);
             }
 


### PR DESCRIPTION
## 🔗 Issue Number
closes #190

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 동일 유저가 같은 가게에 **다른 날짜로 대기 등록 가능하도록 수정**
- [X] `registerWaitlist`, `registerLockWaitlist` 메서드에 모두 반영

