### PR TITLE
refactor(notification): DLQ 재처리 서비스 및 메서드 분리 + 테스트 코드 작성 (#193)

### DIFF
--- a/src/main/java/org/example/tablenow/domain/notification/message/vacancy/consumer/VacancyDlqReprocessor.java
+++ b/src/main/java/org/example/tablenow/domain/notification/message/vacancy/consumer/VacancyDlqReprocessor.java
@@ -1,56 +1,21 @@
 package org.example.tablenow.domain.notification.message.vacancy.consumer;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.example.tablenow.domain.notification.message.vacancy.dto.VacancyEventDto;
+import org.example.tablenow.domain.notification.message.vacancy.service.VacancyRetryService;
 import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.util.Map;
+import static org.example.tablenow.global.constant.RabbitConstant.VACANCY_DLQ;
 
-import static org.example.tablenow.global.constant.RabbitConstant.*;
-
-@Slf4j
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class VacancyDlqReprocessor {
 
-    private final RabbitTemplate rabbitTemplate;
+    private final VacancyRetryService vacancyRetryService;
 
     @RabbitListener(queues = VACANCY_DLQ)
     public void reprocess(Message message) {
-        try {
-            Object object = rabbitTemplate.getMessageConverter().fromMessage(message);
-
-            // Map → DTO 변환 (수동 퍼블리시 할 경우)
-            VacancyEventDto event = (object instanceof Map map)
-                ? VacancyEventDto.builder()
-                .storeId(((Number) map.get("storeId")).longValue())
-                .waitDate(LocalDate.parse((String) map.get("waitDate")))
-                .build()
-                : (VacancyEventDto) object;
-
-            // retry count 확인
-            Integer retryCount = (Integer) message.getMessageProperties().getHeaders().getOrDefault("x-retry-count", 0);
-            if (retryCount >= 3) {
-                log.warn("[DLQ] 재처리 횟수 초과 → storeId={}, retryCount={}", event.getStoreId(), retryCount);
-                return;
-            }
-
-            // retryCount +1 설정 후 재전송
-            MessageProperties props = new MessageProperties();
-            props.setHeader("x-retry-count", retryCount + 1);
-            Message retryMessage = rabbitTemplate.getMessageConverter().toMessage(event, props);
-
-            rabbitTemplate.send(VACANCY_EXCHANGE, VACANCY_ROUTING_KEY, retryMessage);
-            log.info("[DLQ] 재처리 시도 완료 → storeId={}, retryCount={}", event.getStoreId(), retryCount + 1);
-
-        } catch (Exception e) {
-            log.error("[DLQ] 재처리 중 예외 발생", e);
-        }
+        vacancyRetryService.process(message);
     }
 }

--- a/src/main/java/org/example/tablenow/domain/notification/message/vacancy/service/VacancyRetryService.java
+++ b/src/main/java/org/example/tablenow/domain/notification/message/vacancy/service/VacancyRetryService.java
@@ -1,0 +1,75 @@
+package org.example.tablenow.domain.notification.message.vacancy.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.notification.message.vacancy.dto.VacancyEventDto;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.example.tablenow.global.constant.RabbitConstant.VACANCY_EXCHANGE;
+import static org.example.tablenow.global.constant.RabbitConstant.VACANCY_ROUTING_KEY;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VacancyRetryService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    private static final String RETRY_HEADER = "x-retry-count";
+    private static final int MAX_RETRY_COUNT = 3;
+
+    public void process(Message message) {
+        try {
+            VacancyEventDto event = parseMessage(message);
+            int retryCount = extractRetryCount(message);
+
+            if (retryCount >= MAX_RETRY_COUNT) {
+                log.warn("[DLQ] 재처리 횟수 초과 → storeId={}, retryCount={}", event.getStoreId(), retryCount);
+                return;
+            }
+
+            resendMessage(event, retryCount + 1);
+
+        } catch (Exception e) {
+            log.error("[DLQ] 재처리 중 예외 발생", e);
+        }
+    }
+
+    // 메시지를 DTO로 변환
+    private VacancyEventDto parseMessage(Message message) {
+        Object object = rabbitTemplate.getMessageConverter().fromMessage(message);
+        // 수동 퍼블리시일 경우
+        if (object instanceof Map map) {
+            return VacancyEventDto.builder()
+                .storeId(((Number) map.get("storeId")).longValue())
+                .waitDate(LocalDate.parse((String) map.get("waitDate")))
+                .build();
+        }
+
+        return (VacancyEventDto) object;
+    }
+
+    // 메시지 헤더에서 재시도 횟수 추출
+    private int extractRetryCount(Message message) {
+        return (Integer) message.getMessageProperties()
+            .getHeaders()
+            .getOrDefault(RETRY_HEADER, 0);
+    }
+
+    // 메시지에 재시도 횟수 증가 후 다시 전송
+    private void resendMessage(VacancyEventDto event, int nextRetryCount) {
+        MessageProperties props = new MessageProperties();
+        props.setHeader(RETRY_HEADER, nextRetryCount);
+
+        Message retryMessage = rabbitTemplate.getMessageConverter().toMessage(event, props);
+        rabbitTemplate.send(VACANCY_EXCHANGE, VACANCY_ROUTING_KEY, retryMessage);
+
+        log.info("[DLQ] 재처리 시도 완료 → storeId={}, retryCount={}", event.getStoreId(), nextRetryCount);
+    }
+}

--- a/src/test/java/org/example/tablenow/domain/notification/message/vacancy/service/VacancyRetryServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/notification/message/vacancy/service/VacancyRetryServiceTest.java
@@ -1,0 +1,79 @@
+package org.example.tablenow.domain.notification.message.vacancy.service;
+
+import org.example.tablenow.domain.notification.message.vacancy.dto.VacancyEventDto;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.MessageConverter;
+
+import java.time.LocalDate;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VacancyRetryServiceTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private VacancyRetryService vacancyRetryService;
+
+    @Nested
+    class DLQ_재처리 {
+
+        MessageProperties props = new MessageProperties();
+        Message message = mock(Message.class);
+
+        VacancyEventDto dto = VacancyEventDto.builder()
+            .storeId(1L)
+            .waitDate(LocalDate.of(2025, 4, 25))
+            .build();
+
+        @Test
+        void 최대_재시도_초과시_메시지_재전송_안함() {
+            // given
+            props.setHeader("x-retry-count", 3);
+            given(message.getMessageProperties()).willReturn(props);
+
+            MessageConverter mockConverter = mock(MessageConverter.class);
+            given(rabbitTemplate.getMessageConverter()).willReturn(mockConverter);
+            given(mockConverter.fromMessage(message)).willReturn(dto);
+
+            // when
+            vacancyRetryService.process(message);
+
+            // then
+            verify(rabbitTemplate).send(
+                eq("vacancy.exchange"),
+                eq("vacancy.routing.key"),
+                any(Message.class)
+            );
+        }
+
+        @Test
+        void 메시지_재전송() {
+            // given
+            props.setHeader("x-retry-count", 2);
+            given(message.getMessageProperties()).willReturn(props);
+
+            MessageConverter mockConverter = mock(MessageConverter.class);
+            given(rabbitTemplate.getMessageConverter()).willReturn(mockConverter);
+            given(mockConverter.fromMessage(message)).willReturn(dto);
+            given(mockConverter.toMessage(any(), any())).willReturn(mock(Message.class));
+
+            // when
+            vacancyRetryService.process(message);
+
+            // then
+            verify(rabbitTemplate).send(eq("vacancy.exchange"), eq("vacancy.routing.key"), any());
+        }
+    }
+}

--- a/src/test/java/org/example/tablenow/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/reservation/ReservationServiceTest.java
@@ -1,5 +1,6 @@
 package org.example.tablenow.domain.reservation;
 
+import org.example.tablenow.domain.notification.message.vacancy.producer.VacancyProducer;
 import org.example.tablenow.domain.reservation.dto.request.ReservationRequestDto;
 import org.example.tablenow.domain.reservation.dto.request.ReservationStatusChangeRequestDto;
 import org.example.tablenow.domain.reservation.dto.request.ReservationUpdateRequestDto;
@@ -18,7 +19,6 @@ import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
-import org.example.tablenow.global.rabbitmq.vacancy.producer.VacancyProducer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/example/tablenow/domain/waitlist/service/WaitlistServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/waitlist/service/WaitlistServiceTest.java
@@ -85,7 +85,7 @@ class WaitlistServiceTest {
             given(store.getName()).willReturn("테스트 가게");
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(storeService.getStore(10L)).willReturn(store);
-            given(waitlistRepository.existsByUserAndStoreAndIsNotifiedFalse(user, store)).willReturn(false);
+            given(waitlistRepository.existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(user, store, testDate)).willReturn(false);
             given(waitlistRepository.countByStoreAndWaitDateAndIsNotifiedFalse(store, testDate)).willReturn(3L);
             given(waitlistRepository.save(any(Waitlist.class)))
                 .willAnswer(invocation -> {
@@ -135,7 +135,7 @@ class WaitlistServiceTest {
             // given
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(storeService.getStore(10L)).willReturn(store);
-            given(waitlistRepository.existsByUserAndStoreAndIsNotifiedFalse(user, store)).willReturn(true);
+            given(waitlistRepository.existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(user, store, testDate)).willReturn(true);
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
@@ -150,7 +150,7 @@ class WaitlistServiceTest {
             // given
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(storeService.getStore(10L)).willReturn(store);
-            given(waitlistRepository.existsByUserAndStoreAndIsNotifiedFalse(user, store)).willReturn(false);
+            given(waitlistRepository.existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(user, store, testDate)).willReturn(false);
             given(waitlistRepository.countByStoreAndWaitDateAndIsNotifiedFalse(store, testDate)).willReturn(100L);
 
             // when & then
@@ -185,7 +185,7 @@ class WaitlistServiceTest {
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
             given(storeService.getStore(10L)).willReturn(store);
             given(reservationService.hasVacancyDate(store, testDate)).willReturn(false);
-            given(waitlistRepository.existsByUserAndStoreAndIsNotifiedFalse(user, store)).willReturn(false);
+            given(waitlistRepository.existsByUserAndStoreAndWaitDateAndIsNotifiedFalse(user, store, testDate)).willReturn(false);
             given(waitlistRepository.countByStoreAndWaitDateAndIsNotifiedFalse(store, testDate)).willReturn(3L);
             given(waitlistRepository.save(any())).willAnswer(invocation -> {
                 Waitlist waitlist = invocation.getArgument(0);


### PR DESCRIPTION
- VacancyDlqReprocessor → VacancyRetryService로 로직 분리
- 재처리 로직 내부 메서드 분리 (파싱 / 전송 책임 분리)
- VacancyRetryServiceTest 단위 테스트 작성

## 🔗 Issue Number
closes #193


## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X]  DLQ 재처리 로직을 `VacancyDlqReprocessor`에서 `VacancyRetryService`로 분리
- [X] `process()` 내부 로직을 파싱 / 재전송으로 메서드 단위 책임 분리
- [X] 서비스 로직 변경에 따른 테스트 클래스 `VacancyRetryServiceTest` 작성
- [X] 대기등록 서비스 테스트 코드 수정


