### PR TITLE
[fix] 예약 변경 및 삭제 시 ZSET 갱신 로직 추가 및 타임존 기준 변경

### DIFF
--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderRegisterConsumer.java
@@ -7,10 +7,9 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.ZoneOffset;
-
 import static org.example.tablenow.global.constant.RabbitConstant.RESERVATION_REMINDER_REGISTER_QUEUE;
 import static org.example.tablenow.global.constant.RedisKeyConstants.REMINDER_ZSET_KEY;
+import static org.example.tablenow.global.constant.TimeConstants.ZONE_ID_ASIA_SEOUL;
 
 @Slf4j
 @Component
@@ -22,7 +21,8 @@ public class ReminderRegisterConsumer {
     public void handleReminderRegister(ReminderMessage message) {
         try {
             String reservationId = String.valueOf(message.getReservationId());
-            double score = message.getRemindAt().toEpochSecond(ZoneOffset.UTC);
+            double score = message.getRemindAt().atZone(ZONE_ID_ASIA_SEOUL).toEpochSecond();
+
 
             redisTemplate.opsForZSet().add(REMINDER_ZSET_KEY, reservationId, score);
 

--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReminderScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReminderScheduler.java
@@ -9,10 +9,11 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 import static org.example.tablenow.global.constant.RedisKeyConstants.REMINDER_ZSET_KEY;
+import static org.example.tablenow.global.constant.TimeConstants.ZONE_ID_ASIA_SEOUL;
 
 @Slf4j
 @Component
@@ -24,7 +25,9 @@ public class ReminderScheduler {
 
     @Scheduled(fixedRateString = "60000")
     public void pollAndSend() {
-        long now = Instant.now().getEpochSecond();
+        long now = LocalDateTime.now()
+                .atZone(ZONE_ID_ASIA_SEOUL)
+                .toEpochSecond();
         Set<String> due = redisTemplate.opsForZSet().rangeByScore(REMINDER_ZSET_KEY, 0, now);
         if (due == null || due.isEmpty()) return;
 

--- a/src/main/java/org/example/tablenow/global/constant/TimeConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/TimeConstants.java
@@ -1,0 +1,10 @@
+package org.example.tablenow.global.constant;
+
+import java.time.ZoneId;
+
+public final class TimeConstants {
+    private TimeConstants() {}
+
+    public static final String TIME_ZONE_ASIA_SEOUL = "Asia/Seoul";
+    public static final ZoneId ZONE_ID_ASIA_SEOUL = ZoneId.of(TIME_ZONE_ASIA_SEOUL);
+}


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #184 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 예약 취소 및 변경 시 기존 알림 제거 및 MQ 메시지 재발행 처리
- [X] 예약/알림 시간 처리 전반을 KST(Asia/Seoul) 기준으로 통일
- [X] TimeConstants 클래스 추가하여 ZoneId.of("Asia/Seoul") 상수화
- [X] Redis ZSET score 계산 시 UTC → KST로 변경하여 정확한 시간 저장

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- postman에서 테스트 시 사용하는 실제 날짜/시간과 Redis에 저장되는 시간이 달라서
지금까지는 테스트 시 `"2025-04-30T10:00:00Z"`와 같이 데이터를 넣고 사용했지만,
이번 작업에서 KST 기준으로 맞춰 정확한 비교가 가능하도록 수정했습니다.
- `Instant.now()`는 UTC 기준이어서, `LocalDateTime.now().atZone(ZoneId.of("Asia/Seoul"))`으로 비교해야 정확했습니다.
