### PR TITLE
[feat] WebSocket + RabbitMQ 기반 채팅 기능 고도화

### DIFF
--- a/Dockerfile.rabbitmq
+++ b/Dockerfile.rabbitmq
@@ -2,6 +2,3 @@ FROM rabbitmq:3-management
 
 # STOMP (TCP)
 RUN rabbitmq-plugins enable --offline rabbitmq_stomp
-
-# Web STOMP (WebSocket)
-RUN rabbitmq-plugins enable --offline rabbitmq_web_stomp

--- a/Dockerfile.rabbitmq
+++ b/Dockerfile.rabbitmq
@@ -1,0 +1,7 @@
+FROM rabbitmq:3-management
+
+# STOMP (TCP)
+RUN rabbitmq-plugins enable --offline rabbitmq_stomp
+
+# Web STOMP (WebSocket)
+RUN rabbitmq-plugins enable --offline rabbitmq_web_stomp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,15 @@ services:
       retries: 10
 
   rabbitmq:
+    build:
+      context: ./
+      dockerfile: Dockerfile.rabbitmq
     image: rabbitmq:3-management
     container_name: rabbitmq
     ports:
       - "5672:5672"
       - "15672:15672"
+      - "61613:61613"
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}

--- a/src/main/java/org/example/tablenow/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/org/example/tablenow/domain/chat/controller/ChatMessageController.java
@@ -37,7 +37,8 @@ public class ChatMessageController {
 
         // 구독 채널로 메시지 브로드캐스트
         messagingTemplate.convertAndSend(
-                WebSocketConstants.TOPIC_CHAT_PREFIX + savedMessage.getReservationId(),
+                //WebSocketConstants.TOPIC_CHAT_PREFIX_SIMPLE + savedMessage.getReservationId(),    // SimpleBroker: 성능비교를 위해 유지
+                WebSocketConstants.TOPIC_CHAT_PREFIX_RELAY + savedMessage.getReservationId(),       // RabbitMQ Relay
                 ChatMessageResponse.fromChatMessage(savedMessage)
         );
     }

--- a/src/main/java/org/example/tablenow/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/org/example/tablenow/domain/chat/controller/ChatMessageController.java
@@ -27,11 +27,10 @@ public class ChatMessageController {
     public void handleMessage(@Payload @Valid ChatMessageRequest request,
                               SimpMessageHeaderAccessor headerAccessor) {
         Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
-        if (sessionAttributes == null || sessionAttributes.get("userId") == null) {
+        if (sessionAttributes == null || !(sessionAttributes.get("userId") instanceof Long userId)) {
             log.warn("[WebSocket] 사용자 정보 없음 (sessionAttributes 또는 userId 누락)");
             return;
         }
-        Long userId = (Long) sessionAttributes.get("userId");
 
         // 메시지 저장 + 알림 발행
         ChatMessageResponse savedMessage = chatMessageService.saveMessageAndNotify(request, userId);

--- a/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/org/example/tablenow/domain/chat/dto/response/ChatMessageResponse.java
@@ -21,6 +21,10 @@ public class ChatMessageResponse {
     @JsonProperty("isRead")
     private final boolean read;
 
+    private final Long reservationId;
+    private Long ownerId;
+    private Long reservationUserId;
+
     public static ChatMessageResponse fromChatMessage(ChatMessage chatMessage) {
         return ChatMessageResponse.builder()
                 .id(chatMessage.getId())
@@ -30,6 +34,9 @@ public class ChatMessageResponse {
                 .imageUrl(chatMessage.getImageUrl())
                 .createdAt(chatMessage.getCreatedAt())
                 .read(chatMessage.isRead())
+                .reservationId(chatMessage.getReservationId())
+                .ownerId(chatMessage.getOwnerId())
+                .reservationUserId(chatMessage.getReservationUserId())
                 .build();
     }
 }

--- a/src/main/java/org/example/tablenow/domain/chat/message/consumer/ChatConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/chat/message/consumer/ChatConsumer.java
@@ -6,6 +6,8 @@ import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
 import org.example.tablenow.domain.notification.dto.request.NotificationRequestDto;
 import org.example.tablenow.domain.notification.enums.NotificationType;
 import org.example.tablenow.domain.notification.service.NotificationService;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
@@ -50,6 +52,10 @@ public class ChatConsumer {
     private Long determineReceiver(ChatMessageResponse chatMessage) {
         // 채팅방 소유자(ownerId)와 예약자(reservationUserId) 중
         // 메시지 보낸 사람(senderId)을 제외한 사람이 수신자
+        if (chatMessage.getSenderId() == null || chatMessage.getOwnerId() == null || chatMessage.getReservationUserId() == null) {
+            throw new HandledException(ErrorCode.INVALID_CHAT_MESSAGE_USER);
+        }
+
         if (chatMessage.getSenderId().equals(chatMessage.getOwnerId())) {
             return chatMessage.getReservationUserId();
         } else {

--- a/src/main/java/org/example/tablenow/domain/chat/message/consumer/ChatConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/chat/message/consumer/ChatConsumer.java
@@ -1,0 +1,63 @@
+package org.example.tablenow.domain.chat.message.consumer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
+import org.example.tablenow.domain.notification.dto.request.NotificationRequestDto;
+import org.example.tablenow.domain.notification.enums.NotificationType;
+import org.example.tablenow.domain.notification.service.NotificationService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.constant.RabbitConstant.CHAT_QUEUE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatConsumer {
+    private final NotificationService notificationService;
+
+    @RabbitListener(queues = CHAT_QUEUE)
+    public void consume(ChatMessageResponse chatMessage) {
+        if (chatMessage == null) {
+            log.warn("[ChatConsumer] 수신한 메시지가 null입니다.");
+            return;
+        }
+
+        Long receiverId = determineReceiver(chatMessage);
+        if (receiverId == null) {
+            log.warn("[ChatConsumer] receiverId를 결정할 수 없습니다. chatMessage: {}", chatMessage);
+            return;
+        }
+
+        try {
+            notificationService.createNotification(
+                    NotificationRequestDto.builder()
+                            .userId(receiverId)
+                            .type(NotificationType.CHAT)
+                            .content(buildChatContent(chatMessage))
+                            .build()
+            );
+
+            log.info("[ChatConsumer] 채팅 알림 전송 완료 → receiverId={}, reservationId={}",
+                    receiverId, chatMessage.getReservationId());
+
+        } catch (Exception e) {
+            log.error("[ChatConsumer] 채팅 알림 처리 중 예외 발생", e);
+        }
+    }
+
+    private Long determineReceiver(ChatMessageResponse chatMessage) {
+        // 채팅방 소유자(ownerId)와 예약자(reservationUserId) 중
+        // 메시지 보낸 사람(senderId)을 제외한 사람이 수신자
+        if (chatMessage.getSenderId().equals(chatMessage.getOwnerId())) {
+            return chatMessage.getReservationUserId();
+        } else {
+            return chatMessage.getOwnerId();
+        }
+    }
+
+    private String buildChatContent(ChatMessageResponse chatMessage) {
+        return chatMessage.getSenderName()+"에게서 새로운 채팅 메시지가 도착했습니다.";
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/example/tablenow/domain/chat/service/ChatMessageService.java
@@ -13,6 +13,7 @@ import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.service.UserService;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.example.tablenow.global.constant.RabbitConstant.CHAT_EXCHANGE;
+import static org.example.tablenow.global.constant.RabbitConstant.CHAT_ROUTING_KEY;
+
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
@@ -28,21 +32,32 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final ReservationService reservationService;
     private final UserService userService;
+    private final RabbitTemplate rabbitTemplate;
 
     // 참여자 정보 전달용 내부 record
     private record ChatParticipants(Long ownerId, Long reservationUserId) {}
 
     @Transactional
-    public ChatMessage saveMessage(ChatMessageRequest request, Long senderId) {
+    public ChatMessageResponse saveMessageAndNotify(ChatMessageRequest request, Long senderId) {
         ChatParticipants participants = loadChatParticipants(request.getReservationId());
         validateChatParticipant(senderId, participants);
 
-        return chatMessageRepository.save(buildChatMessage(
+        ChatMessage savedMessage = chatMessageRepository.save(buildChatMessage(
                 request,
                 senderId,
                 participants.ownerId(),
                 participants.reservationUserId()
         ));
+
+        ChatMessageResponse response = ChatMessageResponse.fromChatMessage(savedMessage);
+
+        rabbitTemplate.convertAndSend(
+                CHAT_EXCHANGE,
+                CHAT_ROUTING_KEY,
+                response
+        );
+
+        return response;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/example/tablenow/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/example/tablenow/domain/chat/service/ChatMessageService.java
@@ -49,7 +49,7 @@ public class ChatMessageService {
     public ChatAvailabilityResponse isChatAvailable(Long reservationId, Long userId) {
         loadAndValidateChatParticipants(reservationId, userId);
 
-        Reservation reservation = reservationService.getReservation(reservationId);
+        Reservation reservation = reservationService.getReservationWithStore(reservationId);
 
         return ChatAvailabilityResponse.builder()
                 .reservationId(reservationId)
@@ -101,7 +101,7 @@ public class ChatMessageService {
             );
         } else {
             // 최초 채팅일 경우 reservation 정보로 참여자 정보 추출
-            Reservation reservation = reservationService.getReservation(reservationId);
+            Reservation reservation = reservationService.getReservationWithStore(reservationId);
             return new ChatParticipants(
                     reservation.getStore().getUser().getId(),
                     reservation.getUser().getId()

--- a/src/main/java/org/example/tablenow/domain/notification/enums/NotificationType.java
+++ b/src/main/java/org/example/tablenow/domain/notification/enums/NotificationType.java
@@ -4,5 +4,6 @@ package org.example.tablenow.domain.notification.enums;
 public enum NotificationType {
     REMIND,
     VACANCY,
-    EVENT_OPEN
+    EVENT_OPEN,
+    CHAT
 }

--- a/src/main/java/org/example/tablenow/global/config/RabbitConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/RabbitConfig.java
@@ -139,6 +139,25 @@ public class RabbitConfig {
         return BindingBuilder.bind(storeDeleteQueue()).to(storeExchange()).with(STORE_DELETE);
     }
 
+    // 채팅 알림 Queue, Exchange, Binding
+    @Bean
+    public Queue chatQueue() {
+        return new Queue(CHAT_QUEUE, true);
+    }
+
+    @Bean
+    public DirectExchange chatExchange() {
+        return new DirectExchange(CHAT_EXCHANGE);
+    }
+
+    @Bean
+    public Binding chatBinding() {
+        return BindingBuilder
+                .bind(chatQueue())
+                .to(chatExchange())
+                .with(CHAT_ROUTING_KEY);
+    }
+
     // 공통 설정
     @Bean
     public MessageConverter jsonMessageConverter() {

--- a/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package org.example.tablenow.global.config;
 import lombok.RequiredArgsConstructor;
 import org.example.tablenow.global.constant.WebSocketConstants;
 import org.example.tablenow.global.interceptor.JwtHandshakeInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -15,6 +16,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+
+    @Value("${chat.broker}")
+    private String brokerType;
+    @Value("${spring.rabbitmq.username}")
+    private String rabbitmqUsername;
+    @Value("${spring.rabbitmq.password}")
+    private String rabbitmqPassword;
 
     /* 클라이언트가 WebSocket 연결을 시도할 엔드포인트 URL 등록 */
     @Override
@@ -29,6 +37,21 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.setApplicationDestinationPrefixes(WebSocketConstants.APP_DEST_PREFIX); // 클라이언트가 보낼 때 prefix
-        registry.enableSimpleBroker(WebSocketConstants.TOPIC_PREFIX);                   // 서버가 브로드캐스트할 때 prefix
+
+        if ("simple".equalsIgnoreCase(brokerType)) {
+            // [SimpleBroker] 서버 메모리 브로커 사용
+            registry.enableSimpleBroker(WebSocketConstants.TOPIC_PREFIX);
+        } else if ("rabbit".equalsIgnoreCase(brokerType)) {
+            // [RabbitMQ Relay] MQ로 relay
+            registry.enableStompBrokerRelay(WebSocketConstants.TOPIC_PREFIX)
+                    .setRelayHost("localhost")  // RabbitMQ 서버 주소
+                    .setRelayPort(61613)        // RabbitMQ STOMP 포트 (TCP)
+                    .setSystemLogin(rabbitmqUsername)
+                    .setSystemPasscode(rabbitmqPassword)
+                    .setClientLogin(rabbitmqUsername)
+                    .setClientPasscode(rabbitmqPassword);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 brokerType입니다: " + brokerType);
+        }
     }
 }

--- a/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
@@ -40,10 +40,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
         if ("simple".equalsIgnoreCase(brokerType)) {
             // [SimpleBroker] 서버 메모리 브로커 사용
-            registry.enableSimpleBroker(WebSocketConstants.TOPIC_PREFIX);
+            registry.enableSimpleBroker(WebSocketConstants.TOPIC_PREFIX_SIMPLE);
         } else if ("rabbit".equalsIgnoreCase(brokerType)) {
             // [RabbitMQ Relay] MQ로 relay
-            registry.enableStompBrokerRelay(WebSocketConstants.TOPIC_PREFIX)
+            registry.enableStompBrokerRelay(WebSocketConstants.TOPIC_PREFIX_RELAY)
                     .setRelayHost("localhost")  // RabbitMQ 서버 주소
                     .setRelayPort(61613)        // RabbitMQ STOMP 포트 (TCP)
                     .setSystemLogin(rabbitmqUsername)

--- a/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
@@ -26,4 +26,8 @@ public class RabbitConstant {
     public static final String STORE_CREATE_QUEUE = "store.create.queue";
     public static final String STORE_UPDATE_QUEUE = "store.update.queue";
     public static final String STORE_DELETE_QUEUE = "store.delete.queue";
+
+    public static final String CHAT_EXCHANGE = "chat.exchange";
+    public static final String CHAT_QUEUE = "chat.queue";
+    public static final String CHAT_ROUTING_KEY = "chat.key";
 }

--- a/src/main/java/org/example/tablenow/global/constant/WebSocketConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/WebSocketConstants.java
@@ -9,15 +9,17 @@ public final class WebSocketConstants {
     // ex) stompClient.send("/app/chat/message", ...)
     public static final String APP_DEST_PREFIX = "/app";
 
-    // 서버가 메시지를 브로드캐스트할 때 사용하는 prefix
-    // ex) messagingTemplate.convertAndSend("/topic/...")
-    public static final String TOPIC_PREFIX = "/topic";
+    // 서버-클라이언트 간 메시지 전달에 사용하는 브로커 경로 prefix
+    // SimpleBroker 버전 (registry.enableSimpleBroker)
+    public static final String TOPIC_PREFIX_SIMPLE = "/topic";
+    // RabbitMQ Relay 버전 (registry.enableStompBrokerRelay)
+    public static final String TOPIC_PREFIX_RELAY = "/exchange";
 
     // 채팅방 메시지를 브로드캐스트할 때 사용하는 prefix
     // SimpleBroker 버전 (/topic/chat/{reservationId})
     public static final String TOPIC_CHAT_PREFIX_SIMPLE = "/topic/chat/";
     // RabbitMQ Relay 버전 (/exchange/amq.topic/chat/{reservationId})
-    public static final String TOPIC_CHAT_PREFIX_RELAY = "/exchange/amq.topic/chat/";
+    public static final String TOPIC_CHAT_PREFIX_RELAY = "/exchange/amq.topic/chat.";
 
     private WebSocketConstants() {
         // 인스턴스 생성 방지

--- a/src/main/java/org/example/tablenow/global/constant/WebSocketConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/WebSocketConstants.java
@@ -14,8 +14,10 @@ public final class WebSocketConstants {
     public static final String TOPIC_PREFIX = "/topic";
 
     // 채팅방 메시지를 브로드캐스트할 때 사용하는 prefix
-    // ex) /topic/chat/{reservationId}
-    public static final String TOPIC_CHAT_PREFIX = "/topic/chat/";
+    // SimpleBroker 버전 (/topic/chat/{reservationId})
+    public static final String TOPIC_CHAT_PREFIX_SIMPLE = "/topic/chat/";
+    // RabbitMQ Relay 버전 (/exchange/amq.topic/chat/{reservationId})
+    public static final String TOPIC_CHAT_PREFIX_RELAY = "/exchange/amq.topic/chat/";
 
     private WebSocketConstants() {
         // 인스턴스 생성 방지

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -115,7 +115,8 @@ public enum ErrorCode {
     UNPERSISTED_PAYMENT(HttpStatus.BAD_REQUEST, "영속화되지 않은 Payment 객체입니다"),
 
     // CHAT
-    INVALID_CHAT_PARTICIPANT(HttpStatus.FORBIDDEN, "채팅에 참여할 수 있는 권한이 없습니다.");
+    INVALID_CHAT_PARTICIPANT(HttpStatus.FORBIDDEN, "채팅에 참여할 수 있는 권한이 없습니다."),
+    INVALID_CHAT_MESSAGE_USER(HttpStatus.FORBIDDEN, "채팅 메시지 수신자 정보를 확인할 수 없습니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -57,3 +57,6 @@ redisson:
   config:
     singleServerConfig:
       address: "redis://localhost:6379"
+
+chat:
+  broker: rabbit  # or simple

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -62,7 +62,7 @@
                 console.log("[WebSocket] Connected: " + frame);
                 const reservationId = document.getElementById("reservationId").value;
                 //const destination = "/topic/chat/" + reservationId;               // SimpleBroker: 성능비교를 위해 유지
-                const destination = "/exchange/amq.topic/chat/" + reservationId;    // RabbitMQ Relay
+                const destination = "/exchange/amq.topic/chat." + reservationId;    // RabbitMQ Relay
                 console.log("[WebSocket] Subscribing to: ", destination);
 
                 stompClient.subscribe(destination, function (message) {

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -46,24 +46,36 @@
     }
 
     function openNewConnection() {
-        const reservationId = document.getElementById("reservationId").value;
         const token = document.getElementById("accessToken").value;
 
         const socket = new SockJS("/ws/chat?token=" + encodeURIComponent(token));
         stompClient = Stomp.over(socket);
-
         stompClient.debug = console.log;
 
-        stompClient.connect({ Authorization: token }, function (frame) {
-            console.log("Connected: " + frame);
+        stompClient.connect(
+            {
+                login: "myuser",
+                passcode: "mypassword",
+                Authorization: token
+            },
+            function (frame) {
+                console.log("[WebSocket] Connected: " + frame);
+                const reservationId = document.getElementById("reservationId").value;
+                //const destination = "/topic/chat/" + reservationId;               // SimpleBroker: 성능비교를 위해 유지
+                const destination = "/exchange/amq.topic/chat/" + reservationId;    // RabbitMQ Relay
+                console.log("[WebSocket] Subscribing to: ", destination);
 
-            stompClient.subscribe("/topic/chat/" + reservationId, function (message) {
-                const msg = JSON.parse(message.body);
-                const box = document.getElementById("chatBox");
-                box.innerHTML += `<div><b>${msg.senderName}</b>: ${msg.content || '<img src="' + msg.imageUrl + '" width="100"/>'}</div>`;
-                box.scrollTop = box.scrollHeight;
-            });
-        });
+                stompClient.subscribe(destination, function (message) {
+                    const msg = JSON.parse(message.body);
+                    const box = document.getElementById("chatBox");
+                    box.innerHTML += `<div><b>${msg.senderName}</b>: ${msg.content || '<img src="' + msg.imageUrl + '" width="100"/>'}</div>`;
+                    box.scrollTop = box.scrollHeight;
+                });
+            },
+            function (error) {
+                console.error("[WebSocket] 연결 실패: ", error);
+            }
+        );
     }
 
     function sendMessage() {


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #189

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] Spring WebSocket + STOMP 메시지 Relay를 RabbitMQ로 전환
  - 이전 구조 (SimpleBroker)에서는 → 서버(Spring)가 직접 클라이언트에게 메시지를 브로드캐스트
  - 지금 구조 (StompBrokerRelay)에서는 → 서버(Spring)가 직접 브로드캐스트하지 않고, 받은 메시지를 RabbitMQ로 relay
- [X] 클라이언트 구독 경로를 `/exchange/amq.topic/chat.{reservationId}` 형식으로 수정
- [X] 채팅 메시지 저장 시 RabbitMQ를 통해 알림 트리거 구현
- [X] ChatConsumer에서 MQ 수신 후 Notification 테이블에 저장
- [X] NotificationType에 CHAT 타입 추가
- [X] RabbitConfig에 채팅 알림용 Queue, Exchange, Binding 설정 추가


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- WebSocket 연결은 Spring 서버가 담당하고, 메시지 브로커 역할은 RabbitMQ가 수행합니다.
- RabbitMQ STOMP 프로토콜용 TCP 포트(61613)을 추가했습니다.
  - [Spring WebSocket 서버] --(STOMP 프레임 over TCP 61613 포트)--> [RabbitMQ]
- 구독 경로를 `/topic/chat/{reservationId}` → `/exchange/amq.topic/chat.{reservationId}`로 변경했습니다.
  - [Invalid destination 에러](https://www.notion.so/teamsparta/Spring-WebSocket-RabbitMQ-TCP-Relay-Invalid-destination-1e22dc3ef51480b18d8cc0229f3bdfde)
- 채팅 저장과 알림 저장을 완전히 분리하여, 비동기 처리 구조를 적용했습니다.
  - [알림 처리에 대한 고민](https://www.notion.so/teamsparta/RabbitMQ-Relay-1e02dc3ef51480d388aedbbe29690200?pvs=4#1e22dc3ef51480bfb8ccefdeba856883)
- 추후 SimpleBroker vs RabbitMQ Relay 성능 비교(JMeter 부하 테스트) 예정입니다.

> [RabbitMQ Relay 기반 채팅 기능 개선 - 구현 내용 설명](https://www.notion.so/teamsparta/RabbitMQ-Relay-1e02dc3ef51480d388aedbbe29690200?pvs=4#1e02dc3ef5148078a1ecf84c407a2627)

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
- rabbitMQ 61613 포트 추가
![image](https://github.com/user-attachments/assets/7cf6dcf0-9e5e-44c4-b864-a1bf23001250)

- 구독 및 메시지 송/수신 성공 로그
![image](https://github.com/user-attachments/assets/30888514-b3e2-43ca-9269-627a20a364d2)
