### PR TITLE
[feat] ReminderScheduler에 ShedLock 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ dependencies {
 
     // Spring Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // Shedlock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:6.4.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:6.4.0'
 }
 
 def querydslDir = 'src/main/generated'

--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReminderScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReminderScheduler.java
@@ -2,6 +2,7 @@ package org.example.tablenow.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.example.tablenow.domain.reservation.entity.Reservation;
 import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
 import org.example.tablenow.domain.reservation.message.producer.ReminderSendProducer;
@@ -23,6 +24,7 @@ public class ReminderScheduler {
     private final ReminderSendProducer sendProducer;
     private final ReservationService reservationService;
 
+    @SchedulerLock(name = "ReminderScheduler.pollAndSend")
     @Scheduled(fixedRateString = "60000")
     public void pollAndSend() {
         long now = LocalDateTime.now().atZone(ZONE_ID_ASIA_SEOUL).toEpochSecond();

--- a/src/main/java/org/example/tablenow/global/config/SchedulingConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/SchedulingConfig.java
@@ -1,9 +1,24 @@
 package org.example.tablenow.global.config;
 
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@Configuration
+@EnableSchedulerLock(defaultLockAtLeastFor = "30s", defaultLockAtMostFor = "1m")
 @EnableScheduling
+@Configuration
+@RequiredArgsConstructor
 public class SchedulingConfig {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public LockProvider lockProvider() {
+        return new RedisLockProvider(redisConnectionFactory);
+    }
 }

--- a/src/test/java/org/example/tablenow/domain/reservation/ReminderSchedulerTest.java
+++ b/src/test/java/org/example/tablenow/domain/reservation/ReminderSchedulerTest.java
@@ -98,7 +98,7 @@ public class ReminderSchedulerTest {
 
             // then
             verify(sendProducer).send(any(ReminderMessage.class));
-            verify(redisTemplate.opsForZSet()).remove("reminder:zset", reservationId);
+            verify(redisTemplate.opsForZSet()).remove("reservation:reminder:zset", reservationId);
         }
 
         @Test

--- a/src/test/java/org/example/tablenow/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/reservation/ReservationServiceTest.java
@@ -29,6 +29,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -56,30 +58,42 @@ public class ReservationServiceTest {
     @Mock
     private VacancyProducer vacancyProducer;
 
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
     @InjectMocks
     private ReservationService reservationService;
 
-    Long userId = 1L;
-    Long storeId = 10L;
-    AuthUser authUser = new AuthUser(userId, "user@test.com", UserRole.ROLE_USER, "일반회원");
-    User user = User.fromAuthUser(authUser);
-
-    Store store = Store.builder()
-            .id(storeId)
-            .startTime(LocalTime.of(9, 0))
-            .endTime(LocalTime.of(22, 0))
-            .capacity(20)
-            .build();
-
-    LocalDateTime reservedAt = LocalDateTime.of(2025, 4, 10, 10, 0);
-
-    Reservation reserved1;
-    Reservation reserved2;
+    private Long userId;
+    private Long storeId;
+    private AuthUser authUser;
+    private User user;
+    private Store store;
+    private LocalDateTime reservedAt;
+    private Reservation reserved1;
+    private Reservation reserved2;
 
     @BeforeEach
     void setUp() {
-        reserved1 = createReservation(1L, LocalDateTime.of(2025, 4, 10, 10, 0), ReservationStatus.RESERVED);
-        reserved2 = createReservation(2L, LocalDateTime.of(2025, 4, 11, 11, 30), ReservationStatus.RESERVED);
+        userId = 1L;
+        storeId = 10L;
+        authUser = new AuthUser(userId, "user@test.com", UserRole.ROLE_USER, "일반회원");
+        user = User.fromAuthUser(authUser);
+
+        store = Store.builder()
+                .id(storeId)
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(22, 0))
+                .capacity(20)
+                .build();
+
+        reservedAt = LocalDateTime.of(2025, 4, 10, 10, 0);
+
+        reserved1 = createReservation(1L, reservedAt, ReservationStatus.RESERVED);
+        reserved2 = createReservation(2L, reservedAt.plusDays(1), ReservationStatus.RESERVED);
     }
 
     private Reservation createReservation(Long id, LocalDateTime time, ReservationStatus status) {
@@ -96,17 +110,14 @@ public class ReservationServiceTest {
     @Nested
     class 락_기반_예약_생성 {
 
-        ReservationRequestDto dto = ReservationRequestDto.builder()
-                .storeId(storeId)
-                .reservedAt(reservedAt)
-                .build();
+        ReservationRequestDto dto = new ReservationRequestDto(storeId, reservedAt);
 
         @Test
         void 예약_성공() {
             // given
             given(storeService.getStore(anyLong())).willReturn(store);
             given(reservationRepository.countReservedTablesByDate(any(), any())).willReturn(0L);
-            given(reservationRepository.existsByUserIdAndStoreIdAndReservedAt(anyLong(), anyLong(), any())).willReturn(false);
+            given(reservationRepository.existsByUserIdAndStore_IdAndReservedAt(anyLong(), anyLong(), any())).willReturn(false);
             given(reservationRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
@@ -137,7 +148,7 @@ public class ReservationServiceTest {
             // given
             given(storeService.getStore(anyLong())).willReturn(store);
             given(reservationRepository.countReservedTablesByDate(any(), any())).willReturn(0L);
-            given(reservationRepository.existsByUserIdAndStoreIdAndReservedAt(anyLong(), anyLong(), any())).willReturn(true);
+            given(reservationRepository.existsByUserIdAndStore_IdAndReservedAt(anyLong(), anyLong(), any())).willReturn(true);
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
@@ -150,16 +161,14 @@ public class ReservationServiceTest {
 
     @Nested
     class 예약_생성 {
-        ReservationRequestDto dto = ReservationRequestDto.builder()
-                .storeId(storeId)
-                .reservedAt(reservedAt)
-                .build();
+
+        ReservationRequestDto dto = new ReservationRequestDto(storeId, reservedAt);
 
         @Test
         void 이미_같은_유저의_예약이_존재하는_경우_예외_발생() {
             // given
             given(storeService.getStore(anyLong())).willReturn(store);
-            given(reservationRepository.existsByUserIdAndStoreIdAndReservedAt(anyLong(), any(), any())).willReturn(true);
+            given(reservationRepository.existsByUserIdAndStore_IdAndReservedAt(anyLong(), any(), any())).willReturn(true);
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
@@ -172,7 +181,7 @@ public class ReservationServiceTest {
         void 예약_시간이_가게_영업시간이_아니면_예외_발생() {
             // given
             given(storeService.getStore(anyLong())).willReturn(store);
-            given(reservationRepository.existsByUserIdAndStoreIdAndReservedAt(anyLong(), any(), any())).willReturn(false);
+            given(reservationRepository.existsByUserIdAndStore_IdAndReservedAt(anyLong(), any(), any())).willReturn(false);
             ReflectionTestUtils.setField(dto, "reservedAt", LocalDateTime.of(2025, 4, 10, 23, 0));
 
             // when & then
@@ -186,7 +195,7 @@ public class ReservationServiceTest {
         void 예약_성공() {
             // given
             given(storeService.getStore(anyLong())).willReturn(store);
-            given(reservationRepository.existsByUserIdAndStoreIdAndReservedAt(anyLong(), any(), any())).willReturn(false);
+            given(reservationRepository.existsByUserIdAndStore_IdAndReservedAt(anyLong(), any(), any())).willReturn(false);
             given(reservationRepository.save(any(Reservation.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
@@ -202,7 +211,7 @@ public class ReservationServiceTest {
         void 예약_생성_시_MQ_메세지_발송() {
             // given
             given(storeService.getStore(anyLong())).willReturn(store);
-            given(reservationRepository.existsByUserIdAndStoreIdAndReservedAt(anyLong(), any(), any())).willReturn(false);
+            given(reservationRepository.existsByUserIdAndStore_IdAndReservedAt(anyLong(), any(), any())).willReturn(false);
             given(reservationRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
@@ -215,11 +224,9 @@ public class ReservationServiceTest {
 
     @Nested
     class 예약_날짜_수정 {
-        Long reservationId = 1L;
 
-        ReservationUpdateRequestDto dto = ReservationUpdateRequestDto.builder()
-                .reservedAt(reservedAt)
-                .build();
+        Long reservationId = 1L;
+        ReservationUpdateRequestDto dto = new ReservationUpdateRequestDto(reservedAt);
 
         @Test
         void 예약_당사자가_아닌_경우_예외_발생() {
@@ -242,7 +249,7 @@ public class ReservationServiceTest {
             // given
             Reservation reservation = createReservation(reservationId, LocalDateTime.of(2025, 4, 10, 10, 0), ReservationStatus.RESERVED);
             given(reservationRepository.findById(anyLong())).willReturn(Optional.of(reservation));
-            given(reservationRepository.existsByStoreIdAndReservedAtAndIdNot(anyLong(), any(), anyLong())).willReturn(true);
+            given(reservationRepository.existsByStore_IdAndReservedAtAndIdNot(anyLong(), any(), anyLong())).willReturn(true);
 
             // when & then
             HandledException exception = assertThrows(HandledException.class, () ->
@@ -256,7 +263,7 @@ public class ReservationServiceTest {
             // given
             Reservation reservation = createReservation(reservationId, LocalDateTime.of(2025, 4, 10, 10, 0), ReservationStatus.RESERVED);
             given(reservationRepository.findById(anyLong())).willReturn(Optional.of(reservation));
-            given(reservationRepository.existsByStoreIdAndReservedAtAndIdNot(anyLong(), any(), anyLong())).willReturn(false);
+            given(reservationRepository.existsByStore_IdAndReservedAtAndIdNot(anyLong(), any(), anyLong())).willReturn(false);
 
             // when
             ReservationResponseDto response = reservationService.updateReservation(authUser, reservationId, dto);
@@ -269,6 +276,7 @@ public class ReservationServiceTest {
 
     @Nested
     class 내_예약_목록_조회 {
+
         int page = 1;
         int size = 10;
 
@@ -339,6 +347,7 @@ public class ReservationServiceTest {
 
     @Nested
     class 내_가게_예약_목록_조회 {
+
         int page = 1;
         int size = 10;
 
@@ -489,9 +498,7 @@ public class ReservationServiceTest {
                     reservationService.completeReservation(
                             otherAuthUser,
                             1L,
-                            ReservationStatusChangeRequestDto.builder()
-                                    .status(ReservationStatus.COMPLETED)
-                                    .build()
+                            new ReservationStatusChangeRequestDto(ReservationStatus.COMPLETED)
                     )
             );
 
@@ -508,9 +515,7 @@ public class ReservationServiceTest {
             ReservationStatusResponseDto response = reservationService.completeReservation(
                     authUser,
                     1L,
-                    ReservationStatusChangeRequestDto.builder()
-                            .status(ReservationStatus.COMPLETED)
-                            .build()
+                    new ReservationStatusChangeRequestDto(ReservationStatus.COMPLETED)
             );
 
             // then


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
#202 
close #204 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] ShedLock 의존성 추가
- [X] `SchedulingConfig`에 ShedLock 기본 설정 추가
  - `@EnableSchedulerLock(defaultLockAtLeastFor = "30s", defaultLockAtMostFor = "1m")`
- [X] Redis 기반 `LockProvider` 등록
- [X] ReminderScheduler에 `@SchedulerLock(name = "ReminderScheduler.pollAndSend")` 적용
- [X] 테스트 코드 수정


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- [ShedLock 기술적 의사결정](https://www.notion.so/teamsparta/ShedLock-1e32dc3ef51480bf9b44e5afe5fce2e4?pvs=4)
- 스케줄러가 다중 서버 환경에서도 단일 실행되도록 개선했습니다.
- 다른 스케줄러에도 적용 후 이슈 닫도록 하겠습니다.
- PR 닫지 않고 푸쉬해버려서 테스트 코드도 같이 merge됩니다.😓
![image](https://github.com/user-attachments/assets/9c13bfb5-bdef-455d-a245-dd76882fa690)

