### PR TITLE
[feat] EventOpenScheduler에 ShedLock 적용

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/service/EventOpenScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventOpenScheduler.java
@@ -2,6 +2,7 @@ package org.example.tablenow.domain.event.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,8 +14,9 @@ import java.time.LocalDateTime;
 public class EventOpenScheduler {
     private final EventService eventService;
 
-    @Scheduled(fixedRate = 60000) // 1분마다 실행
-    public void runEventOpenScheduler() {
+    @SchedulerLock(name = "EventOpenScheduler.runEventOpen")
+    @Scheduled(fixedRate = 60000)
+    public void runEventOpen() {
         try {
             log.info("이벤트 스케줄러가 실행되었습니다. time={}", LocalDateTime.now());
             eventService.openEventsIfDue();


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #202 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] EventOpenScheduler에 `@SchedulerLock(name = "EventOpenScheduler.runEventOpen")` 적용


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- [ShedLock 기술적 의사결정](https://www.notion.so/teamsparta/ShedLock-1e32dc3ef51480bf9b44e5afe5fce2e4?pvs=4)
- 스케줄러가 다중 서버 환경에서도 단일 실행되도록 개선했습니다.
