### PR TITLE
[refactor] 이벤트 API 리팩토링

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/controller/EventController.java
+++ b/src/main/java/org/example/tablenow/domain/event/controller/EventController.java
@@ -30,24 +30,24 @@ public class EventController {
     }
 
     @Secured(UserRole.Authority.ADMIN)
-    @PatchMapping("/v1/admin/events/{id}")
+    @PatchMapping("/v1/admin/events/{eventId}")
     public ResponseEntity<EventResponseDto> updateEvent(
-            @PathVariable Long id,
+            @PathVariable Long eventId,
             @Valid @RequestBody EventUpdateRequestDto request
     ) {
-        return ResponseEntity.ok(eventService.updateEvent(id, request));
+        return ResponseEntity.ok(eventService.updateEvent(eventId, request));
     }
 
     @Secured(UserRole.Authority.ADMIN)
-    @DeleteMapping("/v1/admin/events/{id}")
-    public ResponseEntity<EventDeleteResponseDto> deleteEvent(@PathVariable Long id) {
-        return ResponseEntity.ok(eventService.deleteEvent(id));
+    @DeleteMapping("/v1/admin/events/{eventId}")
+    public ResponseEntity<EventDeleteResponseDto> deleteEvent(@PathVariable Long eventId) {
+        return ResponseEntity.ok(eventService.deleteEvent(eventId));
     }
 
     @Secured(UserRole.Authority.ADMIN)
-    @PatchMapping("/v1/admin/events/{id}/close")
-    public ResponseEntity<EventCloseResponseDto> closeEvent(@PathVariable Long id) {
-        return ResponseEntity.ok(eventService.closeEvent(id));
+    @PatchMapping("/v1/admin/events/{eventId}/close")
+    public ResponseEntity<EventCloseResponseDto> closeEvent(@PathVariable Long eventId) {
+        return ResponseEntity.ok(eventService.closeEvent(eventId));
     }
 
     @GetMapping("/v1/events")

--- a/src/main/java/org/example/tablenow/domain/event/dto/request/EventRequestDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/request/EventRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class EventRequestDto {
     @NotNull(message = "storeId는 필수입니다.")
     private Long storeId;
@@ -29,15 +30,4 @@ public class EventRequestDto {
     @NotNull
     @Min(value = 1, message = "최소 인원은 1명 이상이어야 합니다.")
     private Integer limitPeople;
-
-    @Builder
-    public EventRequestDto(Long storeId, String content, LocalDateTime openAt, LocalDateTime endAt,
-                           LocalDateTime eventTime, Integer limitPeople) {
-        this.storeId = storeId;
-        this.content = content;
-        this.openAt = openAt;
-        this.endAt = endAt;
-        this.eventTime = eventTime;
-        this.limitPeople = limitPeople;
-    }
 }

--- a/src/main/java/org/example/tablenow/domain/event/dto/request/EventUpdateRequestDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/request/EventUpdateRequestDto.java
@@ -2,7 +2,7 @@ package org.example.tablenow.domain.event.dto.request;
 
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class EventUpdateRequestDto {
     @Future(message = "openAt은 미래 시각이어야 합니다.")
     private LocalDateTime openAt;
@@ -17,11 +18,4 @@ public class EventUpdateRequestDto {
     private LocalDateTime eventTime;
     @Min(value = 1, message = "최소 인원은 1명 이상이어야 합니다.")
     private Integer limitPeople;
-
-    @Builder
-    public EventUpdateRequestDto(LocalDateTime openAt, LocalDateTime eventTime, Integer limitPeople) {
-        this.openAt = openAt;
-        this.eventTime = eventTime;
-        this.limitPeople = limitPeople;
-    }
 }

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventDeleteResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventDeleteResponseDto.java
@@ -22,8 +22,8 @@ public class EventDeleteResponseDto {
     public static EventDeleteResponseDto fromEvent(Event event) {
         return EventDeleteResponseDto.builder()
                 .eventId(event.getId())
-                .storeId(event.getStore().getId())
-                .storeName(event.getStore().getName())
+                .storeId(event.getStoreId())
+                .storeName(event.getStoreName())
                 .message("이벤트 삭제에 성공했습니다.")
                 .build();
     }

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventJoinResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventJoinResponseDto.java
@@ -1,5 +1,6 @@
 package org.example.tablenow.domain.event.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.tablenow.domain.event.entity.EventJoin;
@@ -12,7 +13,9 @@ public class EventJoinResponseDto {
     private final Long eventId;
     private final Long storeId;
     private final String storeName;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime eventTime;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime joinedAt;
     private final String message;
 
@@ -31,10 +34,10 @@ public class EventJoinResponseDto {
     public static EventJoinResponseDto fromEventJoin(EventJoin eventJoin) {
         return EventJoinResponseDto.builder()
                 .eventJoinId(eventJoin.getId())
-                .eventId(eventJoin.getEvent().getId())
-                .storeId(eventJoin.getEvent().getStore().getId())
-                .storeName(eventJoin.getEvent().getStore().getName())
-                .eventTime(eventJoin.getEvent().getEventTime())
+                .eventId(eventJoin.getEventId())
+                .storeId(eventJoin.getStoreId())
+                .storeName(eventJoin.getStoreName())
+                .eventTime(eventJoin.getEventTime())
                 .joinedAt(eventJoin.getJoinedAt())
                 .message("이벤트 예약에 성공했습니다.")
                 .build();

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventResponseDto.java
@@ -1,5 +1,6 @@
 package org.example.tablenow.domain.event.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.tablenow.domain.event.entity.Event;
@@ -13,11 +14,16 @@ public class EventResponseDto {
     private final Long storeId;
     private final String storeName;
     private final String content;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime openAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime endAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime eventTime;
     private final int limitPeople;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime updatedAt;
     private final EventStatus status;
 
@@ -40,8 +46,8 @@ public class EventResponseDto {
     public static EventResponseDto fromEvent(Event event) {
         return EventResponseDto.builder()
                 .eventId(event.getId())
-                .storeId(event.getStore().getId())
-                .storeName(event.getStore().getName())
+                .storeId(event.getStoreId())
+                .storeName(event.getStoreName())
                 .content(event.getContent())
                 .openAt(event.getOpenAt())
                 .endAt(event.getEndAt())

--- a/src/main/java/org/example/tablenow/domain/event/entity/Event.java
+++ b/src/main/java/org/example/tablenow/domain/event/entity/Event.java
@@ -1,6 +1,7 @@
 package org.example.tablenow.domain.event.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,11 +13,12 @@ import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 @Entity
 @Table(name = "event")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event extends TimeStamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -80,10 +82,6 @@ public class Event extends TimeStamped {
         }
     }
 
-    private void changeStatus(EventStatus status) {
-        this.status = status;
-    }
-
     public static Event create(Store store, EventRequestDto dto) {
         return Event.builder()
                 .store(store)
@@ -95,4 +93,19 @@ public class Event extends TimeStamped {
                 .build();
     }
 
+    public Long getStoreId() {
+        return Optional.ofNullable(this.store)
+                .map(Store::getId)
+                .orElse(null);
+    }
+
+    public String getStoreName() {
+        return Optional.ofNullable(this.store)
+                .map(Store::getName)
+                .orElse(null);
+    }
+
+    private void changeStatus(EventStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/org/example/tablenow/domain/event/entity/EventJoin.java
+++ b/src/main/java/org/example/tablenow/domain/event/entity/EventJoin.java
@@ -1,17 +1,19 @@
 package org.example.tablenow.domain.event.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.tablenow.domain.user.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 @Entity
 @Table(name = "event_join")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventJoin {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,7 +41,27 @@ public class EventJoin {
         this.isNotified = false;
     }
 
-    public void markNotified() {
-        this.isNotified = true;
+    public Long getEventId() {
+        return Optional.ofNullable(this.event)
+                .map(Event::getId)
+                .orElse(null);
+    }
+
+    public Long getStoreId() {
+        return Optional.ofNullable(this.event)
+                .map(Event::getStoreId)
+                .orElse(null);
+    }
+
+    public String getStoreName() {
+        return Optional.ofNullable(this.event)
+                .map(Event::getStoreName)
+                .orElse(null);
+    }
+
+    public LocalDateTime getEventTime() {
+        return Optional.ofNullable(this.event)
+                .map(Event::getEventTime)
+                .orElse(null);
     }
 }

--- a/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenConsumer.java
@@ -32,11 +32,7 @@ public class EventOpenConsumer {
         List<User> users = getUsers(message.getEventId());
 
         for (User user : users) {
-            if (Boolean.TRUE.equals(user.getIsAlarmEnabled())) {
-                sendNotification(user, message);
-            } else {
-                log.debug("[EventOpenConsumer] 알림 비활성 유저 → userId={}", user.getId());
-            }
+            sendNotification(user, message);
         }
     }
 

--- a/src/main/java/org/example/tablenow/domain/event/message/dto/EventOpenMessage.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/dto/EventOpenMessage.java
@@ -24,8 +24,8 @@ public class EventOpenMessage {
     public static EventOpenMessage fromEvent(Event event) {
         return EventOpenMessage.builder()
                 .eventId(event.getId())
-                .storeId(event.getStore().getId())
-                .storeName(event.getStore().getName())
+                .storeId(event.getStoreId())
+                .storeName(event.getStoreName())
                 .openAt(event.getOpenAt())
                 .build();
     }

--- a/src/main/java/org/example/tablenow/domain/event/message/producer/EventOpenProducer.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/producer/EventOpenProducer.java
@@ -5,18 +5,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.global.constant.RabbitConstant;
 import org.example.tablenow.domain.event.message.dto.EventOpenMessage;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Async
 public class EventOpenProducer {
     private final RabbitTemplate rabbitTemplate;
 
     public void send(EventOpenMessage message) {
         rabbitTemplate.convertAndSend(
-                RabbitConstant.EVENT_OPEN_EXCHANGE,   // fanout exchange
-                "",                                   // fanout이므로 routingKey는 빈 문자열
+                RabbitConstant.EVENT_OPEN_EXCHANGE,
                 message
         );
 

--- a/src/main/java/org/example/tablenow/domain/event/repository/EventJoinRepository.java
+++ b/src/main/java/org/example/tablenow/domain/event/repository/EventJoinRepository.java
@@ -4,15 +4,8 @@ import org.example.tablenow.domain.event.entity.Event;
 import org.example.tablenow.domain.event.entity.EventJoin;
 import org.example.tablenow.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface EventJoinRepository extends JpaRepository<EventJoin, Long> {
     boolean existsByUserAndEvent(User user, Event event);
     int countByEvent(Event event);
-
-    @Query("SELECT ej.user FROM EventJoin ej WHERE ej.event.id = :eventId")
-    List<User> findUsersByEventId(Long eventId);
-
 }

--- a/src/main/java/org/example/tablenow/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/example/tablenow/domain/event/repository/EventRepository.java
@@ -10,14 +10,11 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
     boolean existsByStoreIdAndEventTime(Long storeId, LocalDateTime eventTime);
     Page<Event> findByStatus(EventStatus status, Pageable pageable);
-    List<Event> findAllByStatusAndOpenAtLessThanEqual(EventStatus status, LocalDateTime now);
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e FROM Event e WHERE e.id = :id")
     Optional<Event> findByIdForUpdate(Long id);

--- a/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventJoinService.java
@@ -13,23 +13,20 @@ import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static org.example.tablenow.global.constant.RedisKeyConstants.EVENT_LOCK_KEY_PREFIX;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class EventJoinService {
 
     private final EventJoinRepository eventJoinRepository;
     private final EventRepository eventRepository;
     private final EventJoinExecutor eventJoinExecutor;
 
-    @Transactional
     public EventJoinResponseDto joinEventWithoutLock(Long eventId, AuthUser authUser) {
         User user = User.fromAuthUser(authUser);
         Event event = eventRepository.findById(eventId)
@@ -54,7 +51,6 @@ public class EventJoinService {
         return EventJoinResponseDto.fromEventJoin(eventJoin);
     }
 
-    @Transactional
     public EventJoinResponseDto joinEventWithDBLock(Long eventId, AuthUser authUser) {
         User user = User.fromAuthUser(authUser);
         Event event = eventRepository.findByIdForUpdate(eventId)
@@ -83,12 +79,7 @@ public class EventJoinService {
             prefix = EVENT_LOCK_KEY_PREFIX,
             key = "#eventId"
     )
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public EventJoinResponseDto joinEventWithRedissonLock(Long eventId, AuthUser authUser) {
         return eventJoinExecutor.execute(eventId, authUser);
-    }
-
-    public List<User> getUsersByEventId(Long id) {
-        return eventJoinRepository.findUsersByEventId(id);
     }
 }

--- a/src/main/java/org/example/tablenow/domain/event/service/EventService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventService.java
@@ -93,7 +93,8 @@ public class EventService {
         validateReadyStatus(event);
 
         eventRepository.delete(event);
-        redisTemplate.opsForZSet().remove(EVENT_JOIN_PREFIX, String.valueOf(id));
+        redisTemplate.opsForZSet().remove(EVENT_OPEN_KEY, String.valueOf(id));
+        redisTemplate.delete(EVENT_JOIN_PREFIX + id);
         return EventDeleteResponseDto.fromEvent(event);
     }
 
@@ -103,7 +104,8 @@ public class EventService {
 
         event.close();
 
-        redisTemplate.opsForZSet().remove(EVENT_JOIN_PREFIX, String.valueOf(id));
+        redisTemplate.opsForZSet().remove(EVENT_OPEN_KEY, String.valueOf(id));
+        redisTemplate.delete(EVENT_JOIN_PREFIX + id);
         return EventCloseResponseDto.fromEvent(event);
     }
 

--- a/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
@@ -8,12 +8,12 @@ public class RedisKeyConstants {
 
     // 예약 관련
     public static final String REMINDER_ZSET_KEY = RESERVATION_PREFIX + "reminder:zset";
-    public static final String RESERVATION_LOCK_KEY_PREFIX = LOCK_PREFIX + "reservation";
+    public static final String RESERVATION_LOCK_KEY_PREFIX = LOCK_PREFIX + "reservation:";
 
     // 이벤트 관련
-    public static final String EVENT_JOIN_PREFIX = EVENT_PREFIX + "join";
-    public static final String EVENT_LOCK_KEY_PREFIX = LOCK_PREFIX + "event";
-    public static final String EVENT_OPEN_KEY = EVENT_PREFIX + "open";
+    public static final String EVENT_JOIN_PREFIX = EVENT_PREFIX + "join:";
+    public static final String EVENT_LOCK_KEY_PREFIX = LOCK_PREFIX + "event:";
+    public static final String EVENT_OPEN_KEY = EVENT_PREFIX + "open:zset";
 
     private RedisKeyConstants() {}
 }


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #216 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 각 엔티티에서 `@NoArgsConstructor(access = AccessLevel.PROTECTED)`로 변경
- [X] private 메서드를 pulic 메서드 아래로 이동
- [X] 연관관계를 좁히기 위한 메서드 추가
  - `Event` :  `getStoreId()`, `getStoreName()`
  - `EventJoin` : `getEventId()`, `getStoreId()`, `getStoreName()`, `getEventTime()`
  - 그에 따른 응답 DTO 내부 코드 수정
- [X] LocalDateTime 타입 필드에 `@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")` 추가
- [X] 불필요한 중복 검증 코드 제거
- [X] 각 Producer에서 라우팅키 자리의 빈 문자열 제거 및 `@Async` 추가
- [X] 요청 DTO의 `@builder` 제거 후 `@AllArgsConstructor` 추가
- [X] 변수명 변경 및 미사용 메서드 제거
- [X] 이벤트 삭제/수정 시 누락된 기능 추가 및 타임존 통일
- [X] 이벤트 삭제 시 `event:join:<eventId>`로 저장된 참가자 목록도 같이 삭제하도록 수정

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- 누락된 부분이나 오류가 있으면 리뷰 부탁드립니다!