### PR TITLE
[refactor] WebSocket 리팩토링 및 ChatMessageService 단위 테스트 코드 작성

### DIFF
--- a/src/main/java/org/example/tablenow/domain/chat/config/RabbitMQProperties.java
+++ b/src/main/java/org/example/tablenow/domain/chat/config/RabbitMQProperties.java
@@ -1,0 +1,13 @@
+package org.example.tablenow.domain.chat.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "spring.rabbitmq")
+public class RabbitMQProperties {
+    private final String username;
+    private final String password;
+}

--- a/src/main/java/org/example/tablenow/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/org/example/tablenow/domain/chat/controller/ChatMessageController.java
@@ -7,6 +7,9 @@ import org.example.tablenow.domain.chat.dto.request.ChatMessageRequest;
 import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
 import org.example.tablenow.domain.chat.service.ChatMessageService;
 import org.example.tablenow.global.constant.WebSocketConstants;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -23,23 +26,40 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate messagingTemplate;
 
+    @Value("${chat.broker}")
+    private String brokerType;
+
     @MessageMapping("/chat/message")
     public void handleMessage(@Payload @Valid ChatMessageRequest request,
                               SimpMessageHeaderAccessor headerAccessor) {
         Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        log.info("[WebSocket] 현재 세션 Attribute: {}", sessionAttributes);
         if (sessionAttributes == null || !(sessionAttributes.get("userId") instanceof Long userId)) {
             log.warn("[WebSocket] 사용자 정보 없음 (sessionAttributes 또는 userId 누락)");
             return;
         }
 
+        log.info("[WebSocket] 클라이언트 → 서버 메시지 수신 - reservationId: {}, senderId: {}, content: {}",
+                request.getReservationId(), userId, request.getContent());
+
         // 메시지 저장 + 알림 발행
         ChatMessageResponse savedMessage = chatMessageService.saveMessageAndNotify(request, userId);
 
         // 구독 채널로 메시지 브로드캐스트
-        messagingTemplate.convertAndSend(
-                //WebSocketConstants.TOPIC_CHAT_PREFIX_SIMPLE + savedMessage.getReservationId(),    // SimpleBroker: 성능비교를 위해 유지
-                WebSocketConstants.TOPIC_CHAT_PREFIX_RELAY + savedMessage.getReservationId(),       // RabbitMQ Relay
-                savedMessage
-        );
+        if ("simple".equalsIgnoreCase(brokerType)) {
+            // [SimpleBroker] 서버 메모리 브로커 사용
+            messagingTemplate.convertAndSend(
+                    WebSocketConstants.TOPIC_CHAT_PREFIX_SIMPLE + savedMessage.getReservationId(),
+                    savedMessage
+            );
+        } else if ("rabbit".equalsIgnoreCase(brokerType)) {
+            // [RabbitMQ Relay] MQ로 relay
+            messagingTemplate.convertAndSend(
+                    WebSocketConstants.TOPIC_CHAT_PREFIX_RELAY + savedMessage.getReservationId(),       // RabbitMQ Relay
+                    savedMessage
+            );
+        } else {
+            throw new HandledException(ErrorCode.UNSUPPORTED_CHAT_BROKER_TYPE);
+        }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/org/example/tablenow/domain/chat/dto/request/ChatMessageRequest.java
@@ -1,10 +1,12 @@
 package org.example.tablenow.domain.chat.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.example.tablenow.domain.image.annotation.ImageUrlPattern;
 
 @Getter
+@AllArgsConstructor
 public class ChatMessageRequest {
 
     @NotNull(message = "예약 아이디는 필수입니다.")

--- a/src/main/java/org/example/tablenow/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/example/tablenow/domain/chat/entity/ChatMessage.java
@@ -45,7 +45,9 @@ public class ChatMessage {
     private LocalDateTime createdAt;
 
     @Builder
-    public ChatMessage(Long reservationId, User sender, Long ownerId, Long reservationUserId, String content, String imageUrl, boolean isRead, LocalDateTime createdAt) {
+    private ChatMessage(Long id, Long reservationId, User sender, Long ownerId, Long reservationUserId,
+                       String content, String imageUrl, boolean isRead, LocalDateTime createdAt) {
+        this.id = id;
         this.reservationId = reservationId;
         this.sender = sender;
         this.ownerId = ownerId;
@@ -54,9 +56,5 @@ public class ChatMessage {
         this.imageUrl = imageUrl;
         this.isRead = isRead;
         this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
-    }
-
-    public void changeToRead() {
-        this.isRead = true;
     }
 }

--- a/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/WebSocketConfig.java
@@ -1,36 +1,41 @@
 package org.example.tablenow.global.config;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.tablenow.domain.chat.config.RabbitMQProperties;
 import org.example.tablenow.global.constant.WebSocketConstants;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
 import org.example.tablenow.global.interceptor.JwtHandshakeInterceptor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+@Slf4j
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
+    private final RabbitMQProperties rabbitMQProperties;
 
     @Value("${chat.broker}")
     private String brokerType;
-    @Value("${spring.rabbitmq.username}")
-    private String rabbitmqUsername;
-    @Value("${spring.rabbitmq.password}")
-    private String rabbitmqPassword;
 
     /* 클라이언트가 WebSocket 연결을 시도할 엔드포인트 URL 등록 */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint(WebSocketConstants.ENDPOINT_CHAT)
                 .setAllowedOriginPatterns("*")
-                .addInterceptors(jwtHandshakeInterceptor)
-                .withSockJS();
+                .addInterceptors(jwtHandshakeInterceptor);
     }
 
     /* 클라이언트가 메시지를 보낼 때의 prefix 설정 */
@@ -46,12 +51,25 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             registry.enableStompBrokerRelay(WebSocketConstants.TOPIC_PREFIX_RELAY)
                     .setRelayHost("localhost")  // RabbitMQ 서버 주소
                     .setRelayPort(61613)        // RabbitMQ STOMP 포트 (TCP)
-                    .setSystemLogin(rabbitmqUsername)
-                    .setSystemPasscode(rabbitmqPassword)
-                    .setClientLogin(rabbitmqUsername)
-                    .setClientPasscode(rabbitmqPassword);
+                    .setSystemLogin(rabbitMQProperties.getUsername())
+                    .setSystemPasscode(rabbitMQProperties.getPassword())
+                    .setClientLogin(rabbitMQProperties.getUsername())
+                    .setClientPasscode(rabbitMQProperties.getPassword());
         } else {
-            throw new IllegalArgumentException("지원하지 않는 brokerType입니다: " + brokerType);
+            throw new HandledException(ErrorCode.UNSUPPORTED_CHAT_BROKER_TYPE);
         }
+    }
+
+    /* 클라이언트 → 서버로 들어오는 메시지를 가로챈다 */
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                // 여기서 모든 수신 메시지를 잡을 수 있음
+                log.info("[WebSocket Inbound] 수신한 메시지: {}", message.getHeaders());
+                return message;
+            }
+        });
     }
 }

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -116,7 +116,8 @@ public enum ErrorCode {
 
     // CHAT
     INVALID_CHAT_PARTICIPANT(HttpStatus.FORBIDDEN, "채팅에 참여할 수 있는 권한이 없습니다."),
-    INVALID_CHAT_MESSAGE_USER(HttpStatus.FORBIDDEN, "채팅 메시지 수신자 정보를 확인할 수 없습니다.");
+    INVALID_CHAT_MESSAGE_USER(HttpStatus.FORBIDDEN, "채팅 메시지 수신자 정보를 확인할 수 없습니다."),
+    UNSUPPORTED_CHAT_BROKER_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "지원하지 않는 채팅 브로커 타입입니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -48,7 +48,7 @@
     function openNewConnection() {
         const token = document.getElementById("accessToken").value;
 
-        const socket = new SockJS("/ws/chat?token=" + encodeURIComponent(token));
+        const socket = new WebSocket("/ws/chat?token=" + encodeURIComponent(token));
         stompClient = Stomp.over(socket);
         stompClient.debug = console.log;
 

--- a/src/test/java/org/example/tablenow/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,245 @@
+package org.example.tablenow.domain.chat.service;
+
+import org.example.tablenow.domain.chat.dto.request.ChatMessageRequest;
+import org.example.tablenow.domain.chat.dto.response.ChatAvailabilityResponse;
+import org.example.tablenow.domain.chat.dto.response.ChatMessageResponse;
+import org.example.tablenow.domain.chat.dto.response.ChatReadStatusResponse;
+import org.example.tablenow.domain.chat.entity.ChatMessage;
+import org.example.tablenow.domain.chat.repository.ChatMessageRepository;
+import org.example.tablenow.domain.reservation.entity.Reservation;
+import org.example.tablenow.domain.reservation.service.ReservationService;
+import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.domain.user.service.UserService;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+    @Mock
+    private ReservationService reservationService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long RESERVATION_USER_ID = 2L;
+    private static final Long RESERVATION_ID = 10L;
+
+    @Nested
+    class 채팅_저장_및_알림_발송 {
+
+        Reservation reservation;
+
+        @BeforeEach
+        void setUp() {
+            reservation = mockReservation(OWNER_ID, RESERVATION_USER_ID);
+        }
+
+        @Test
+        void 채팅_참여자가_아니면_예외처리() {
+            // given
+            Long invalidSenderId = 99L;
+            ChatMessageRequest request = new ChatMessageRequest(RESERVATION_ID, "Hello", null);
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.empty());
+            given(reservationService.getReservationWithStore(RESERVATION_ID)).willReturn(reservation);
+
+            // when & then
+            assertThatThrownBy(() -> chatMessageService.saveMessageAndNotify(request, invalidSenderId))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessageContaining(ErrorCode.INVALID_CHAT_PARTICIPANT.getDefaultMessage());
+        }
+
+        @Test
+        void 채팅_저장_및_알림_발송_성공() {
+            // given
+            Long senderId = OWNER_ID;
+            ChatMessageRequest request = new ChatMessageRequest(RESERVATION_ID, "Hello", null);
+
+            User sender = User.builder().id(senderId).build();
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.empty());
+            given(reservationService.getReservationWithStore(RESERVATION_ID)).willReturn(reservation);
+            given(userService.getUser(senderId)).willReturn(sender);
+            given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(buildChatMessage(request, senderId, reservation));
+
+            // when
+            ChatMessageResponse response = chatMessageService.saveMessageAndNotify(request, senderId);
+
+            // then
+            assertThat(response.getReservationId()).isEqualTo(RESERVATION_ID);
+            verify(rabbitTemplate).convertAndSend(anyString(), anyString(), any(ChatMessageResponse.class));
+        }
+    }
+
+    @Nested
+    class 채팅_가능여부_조회 {
+
+        Reservation reservation;
+
+        @BeforeEach
+        void setUp() {
+            reservation = mockReservation(OWNER_ID, RESERVATION_USER_ID);
+        }
+
+        @Test
+        void 채팅_참여자가_아니면_예외처리() {
+            // given
+            Long invalidUserId = 99L;
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.empty());
+            given(reservationService.getReservationWithStore(RESERVATION_ID)).willReturn(reservation);
+
+            // when & then
+            assertThatThrownBy(() -> chatMessageService.isChatAvailable(RESERVATION_ID, invalidUserId))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessageContaining(ErrorCode.INVALID_CHAT_PARTICIPANT.getDefaultMessage());
+        }
+
+        @Test
+        void 채팅_가능여부_조회_성공() {
+            // given
+            Long userId = RESERVATION_USER_ID;
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.empty());
+            given(reservationService.getReservationWithStore(RESERVATION_ID)).willReturn(reservation);
+
+            // when
+            ChatAvailabilityResponse response = chatMessageService.isChatAvailable(RESERVATION_ID, userId);
+
+            // then
+            assertThat(response.isAvailable()).isTrue();
+            assertThat(response.getReason()).isEqualTo(reservation.getStatus().name());
+        }
+    }
+
+    @Nested
+    class 채팅_메시지_목록_조회 {
+
+        @Test
+        void 채팅_메시지_목록_조회_성공() {
+            // given
+            Long userId = OWNER_ID;
+            PageRequest pageable = PageRequest.of(0, 10);
+
+            ChatMessage chatMessage = buildChatMessage("Hi", RESERVATION_ID, userId, OWNER_ID, RESERVATION_USER_ID);
+            Page<ChatMessage> page = new PageImpl<>(List.of(chatMessage));
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.of(chatMessage));
+            given(chatMessageRepository.findByReservationId(RESERVATION_ID, pageable)).willReturn(page);
+
+            // when
+            Page<ChatMessageResponse> responses = chatMessageService.getMessages(RESERVATION_ID, userId, pageable);
+
+            // then
+            assertAll(
+                    () -> assertThat(responses.getContent()).hasSize(1),
+                    () -> assertEquals(responses.getContent().get(0).getContent(), chatMessage.getContent())
+            );
+        }
+    }
+
+    @Nested
+    class 읽음상태_변경 {
+
+        @Test
+        void 채팅_참여자가_아니면_예외처리() {
+            // given
+            Long invalidUserId = 99L;
+            Long correctUserId = OWNER_ID;
+
+            ChatMessage chatMessage = buildChatMessage("Hi", RESERVATION_ID, correctUserId, OWNER_ID, RESERVATION_USER_ID);
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.of(chatMessage));
+
+            // when & then
+            assertThatThrownBy(() -> chatMessageService.changeReadStatus(RESERVATION_ID, invalidUserId))
+                    .isInstanceOf(HandledException.class)
+                    .hasMessageContaining(ErrorCode.INVALID_CHAT_PARTICIPANT.getDefaultMessage());
+        }
+
+        @Test
+        void 읽음상태_변경_성공() {
+            // given
+            Long userId = OWNER_ID;
+
+            ChatMessage chatMessage = buildChatMessage("Hi", RESERVATION_ID, userId, OWNER_ID, RESERVATION_USER_ID);
+
+            given(chatMessageRepository.findTop1ByReservationIdOrderByCreatedAtDesc(RESERVATION_ID)).willReturn(Optional.of(chatMessage));
+            given(chatMessageRepository.updateUnreadMessagesAsRead(RESERVATION_ID, userId)).willReturn(5);
+
+            // when
+            ChatReadStatusResponse response = chatMessageService.changeReadStatus(RESERVATION_ID, userId);
+
+            // then
+            assertThat(response.getMessage()).isEqualTo("5개의 메시지 읽음 처리가 완료되었습니다.");
+        }
+    }
+
+    private Reservation mockReservation(Long ownerId, Long userId) {
+        User owner = User.builder().id(ownerId).build();
+        User user = User.builder().id(userId).build();
+        Store store = Store.builder().user(owner).build();
+        return Reservation.builder()
+                .store(store)
+                .user(user)
+                .reservedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ChatMessage buildChatMessage(ChatMessageRequest request, Long senderId, Reservation reservation) {
+        return ChatMessage.builder()
+                .reservationId(request.getReservationId())
+                .sender(User.builder().id(senderId).build())
+                .ownerId(reservation.getStore().getUser().getId())
+                .reservationUserId(reservation.getUser().getId())
+                .content(request.getContent())
+                .createdAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+    }
+
+    private ChatMessage buildChatMessage(String content, Long reservationId, Long senderId, Long ownerId, Long reservationUserId) {
+        return ChatMessage.builder()
+                .reservationId(reservationId)
+                .sender(User.builder().id(senderId).build())
+                .ownerId(ownerId)
+                .reservationUserId(reservationUserId)
+                .content(content)
+                .createdAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #229
close #231

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
### WebSocket 리팩토링 및 로깅 개선
- [X] SockJS에서 WebSocket 표준 객체로 전환
- [X] ChatMessageController에 클라이언트 메시지 수신 로그 추가
- [X] ChatMessageController에서 브로커 타입에 따라 메시지 전송 분기
- [X] WebSocketConfig에 클라이언트 수신 메시지 로깅 인터셉터 추가
- [X] RabbitMQProperties로 RabbitMQ 설정값 주입 방식 리팩토링

### ChatMessageService 단위 테스트 코드 작성
- [X] ChatMessageService의 주요 메서드에 대해 단위 테스트 작성

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- [Gatling를 이용한 WebSocket SimpleBroker vs RabbitMQ 성능 비교 테스트](https://www.notion.so/teamsparta/Gatling-WebSocket-SimpleBroker-vs-RabbitMQ-1e32dc3ef5148028a181df680428622d?pvs=4) 진행하면서 수정한 사항입니다.