### PR TITLE
[refactor] Auth 도메인 Dto 어노테이션 정리 및 Token 관련 Redis 키 상수 이동

### DIFF
--- a/src/main/java/org/example/tablenow/domain/auth/dto/request/SigninRequest.java
+++ b/src/main/java/org/example/tablenow/domain/auth/dto/request/SigninRequest.java
@@ -2,11 +2,11 @@ package org.example.tablenow.domain.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@Builder
 @Getter
+@AllArgsConstructor
 public class SigninRequest {
 
     @Email

--- a/src/main/java/org/example/tablenow/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/tablenow/domain/auth/dto/request/SignupRequest.java
@@ -4,12 +4,13 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.example.tablenow.domain.user.enums.UserRole;
 import org.example.tablenow.global.constant.RegexConstants;
 
 @Getter
+@AllArgsConstructor
 public class SignupRequest {
 
     @Email
@@ -37,14 +38,4 @@ public class SignupRequest {
 
     @NotNull(message = "유저 타입 정보는 필수입니다.")
     private UserRole userRole;
-
-    @Builder
-    private SignupRequest(String email, String password, String name, String nickname, String phoneNumber, UserRole userRole) {
-        this.email = email;
-        this.password = password;
-        this.name = name;
-        this.nickname = nickname;
-        this.phoneNumber = phoneNumber;
-        this.userRole = userRole;
-    }
 }

--- a/src/main/java/org/example/tablenow/domain/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/dto/response/AccessTokenResponse.java
@@ -2,11 +2,9 @@ package org.example.tablenow.domain.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Builder
 @Getter
-@RequiredArgsConstructor
 public class AccessTokenResponse {
 
     private final String accessToken;

--- a/src/main/java/org/example/tablenow/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/dto/response/SignupResponse.java
@@ -2,11 +2,9 @@ package org.example.tablenow.domain.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 public class SignupResponse {
     private final Long id;
     private final String email;

--- a/src/main/java/org/example/tablenow/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/dto/response/TokenResponse.java
@@ -2,11 +2,9 @@ package org.example.tablenow.domain.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 public class TokenResponse {
 
     private final String accessToken;

--- a/src/main/java/org/example/tablenow/domain/auth/oAuth/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/oAuth/kakao/KakaoUserInfoResponse.java
@@ -1,17 +1,18 @@
 package org.example.tablenow.domain.auth.oAuth.kakao;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoUserInfoResponse {
 
     private Long id;
     private KakaoAccount kakao_account;
 
     @Getter
-    @NoArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class KakaoAccount {
         private String email;
         private String name;
@@ -19,7 +20,7 @@ public class KakaoUserInfoResponse {
         private Profile profile;
 
         @Getter
-        @NoArgsConstructor
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
         public static class Profile {
             private String nickname;
             private String profile_image_url;

--- a/src/main/java/org/example/tablenow/domain/auth/oAuth/naver/NaverUserInfoResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/oAuth/naver/NaverUserInfoResponse.java
@@ -1,10 +1,11 @@
 package org.example.tablenow.domain.auth.oAuth.naver;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NaverUserInfoResponse {
 
     private String resultcode;
@@ -12,7 +13,7 @@ public class NaverUserInfoResponse {
     private Response response;
 
     @Getter
-    @NoArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Response {
         private String id;
         private String name;

--- a/src/main/java/org/example/tablenow/domain/auth/service/TokenService.java
+++ b/src/main/java/org/example/tablenow/domain/auth/service/TokenService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.auth.dto.token.RefreshToken;
 import org.example.tablenow.domain.user.entity.User;
+import org.example.tablenow.global.constant.RedisKeyConstants;
 import org.example.tablenow.global.constant.SecurityConstants;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
@@ -36,7 +37,7 @@ public class TokenService {
 
     public String createRefreshToken(User user) {
         String refreshToken = UUID.randomUUID().toString();
-        String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
+        String redisKey = RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
 
         try {
             // userId를 값으로 Redis에 저장
@@ -55,7 +56,7 @@ public class TokenService {
     }
 
     public RefreshToken validateRefreshToken(String refreshToken, Long userId) {
-        String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
+        String redisKey = RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
 
         try {
             String userIdValue = redisTemplate.opsForValue().get(redisKey);
@@ -78,7 +79,7 @@ public class TokenService {
     }
 
     public void deleteRefreshToken(String refreshToken) {
-        String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
+        String redisKey = RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + refreshToken;
 
         try {
             Boolean deleted = redisTemplate.delete(redisKey);
@@ -93,7 +94,7 @@ public class TokenService {
     public void addToBlacklist(String accessToken, Long userId, BlacklistReason reason) {
         try {
             String jwt = jwtUtil.substringToken(accessToken);
-            String redisKey = SecurityConstants.BLACKLIST_TOKEN_KEY_PREFIX + jwt;
+            String redisKey = RedisKeyConstants.BLACKLIST_TOKEN_KEY_PREFIX + jwt;
             long ttl = jwtUtil.getRemainingTokenTime(jwt);
             String value = String.format("%s:userId=%d", reason.getValue(), userId);
 

--- a/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
@@ -15,5 +15,9 @@ public class RedisKeyConstants {
     public static final String EVENT_LOCK_KEY_PREFIX = LOCK_PREFIX + "event:";
     public static final String EVENT_OPEN_KEY = EVENT_PREFIX + "open:zset";
 
+    // 토큰 관련
+    public static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
+    public static final String BLACKLIST_TOKEN_KEY_PREFIX = "blacklistToken:";
+
     private RedisKeyConstants() {}
 }

--- a/src/main/java/org/example/tablenow/global/constant/SecurityConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/SecurityConstants.java
@@ -5,10 +5,6 @@ public final class SecurityConstants {
     public static final String BEARER_PREFIX = "Bearer ";
     public static final long REFRESH_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60L;
 
-    // Redis Key Prefix
-    public static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
-    public static final String BLACKLIST_TOKEN_KEY_PREFIX = "blacklistToken:";
-
     private SecurityConstants() {
         // 인스턴스 생성 방지
     }

--- a/src/main/java/org/example/tablenow/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/tablenow/global/filter/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.user.enums.UserRole;
+import org.example.tablenow.global.constant.RedisKeyConstants;
 import org.example.tablenow.global.constant.SecurityConstants;
 import org.example.tablenow.global.dto.AuthUser;
 import org.example.tablenow.global.security.token.JwtAuthenticationToken;
@@ -44,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String jwt = jwtUtil.substringToken(authorizationHeader);
 
             // AccessToken 블랙리스트 검증
-            String blacklistKey = SecurityConstants.BLACKLIST_TOKEN_KEY_PREFIX + jwt;
+            String blacklistKey = RedisKeyConstants.BLACKLIST_TOKEN_KEY_PREFIX + jwt;
             Boolean isBlacklisted = redisTemplate.hasKey(blacklistKey);
             if (isBlacklisted) {
                 String message = "블랙리스트에 등록된 JWT 토큰입니다.";

--- a/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
@@ -42,19 +42,19 @@ class AuthServiceTest {
 
     @BeforeEach
     void setUp() {
-        signupRequest = SignupRequest.builder()
-                .email("user@test.com")
-                .password("password")
-                .name("이름")
-                .nickname("닉네임")
-                .phoneNumber("01012345678")
-                .userRole(UserRole.ROLE_USER)
-                .build();
+        signupRequest = new SignupRequest(
+                "user@test.com",
+                "password",
+                "이름",
+                "닉네임",
+                "01012345678",
+                UserRole.ROLE_USER
+        );
 
-        signinRequest = SigninRequest.builder()
-                .email(signupRequest.getEmail())
-                .password(signupRequest.getPassword())
-                .build();
+        signinRequest = new SigninRequest(
+                signupRequest.getEmail(),
+                signupRequest.getPassword()
+        );
     }
 
     @Nested
@@ -100,10 +100,10 @@ class AuthServiceTest {
         @Test
         void 존재하지_않는_이메일로_로그인_시_예외처리() {
             // given
-            SigninRequest invalidRequest = SigninRequest.builder()
-                    .email("invalid@test.com")
-                    .password("password")
-                    .build();
+            SigninRequest invalidRequest = new SigninRequest(
+                    "invalid@test.com",
+                    "password"
+            );
 
             // when & then
             assertThatThrownBy(() -> authService.signin(invalidRequest))
@@ -126,10 +126,10 @@ class AuthServiceTest {
         @Test
         void 비밀번호가_저장된_비밀번호와_일치하지_않을_시_예외처리() {
             // given
-            SigninRequest wrongPasswordRequest = SigninRequest.builder()
-                    .email("user@test.com")
-                    .password("wrongPassword")
-                    .build();
+            SigninRequest wrongPasswordRequest = new SigninRequest(
+                    "user@test.com",
+                    "wrongPassword"
+            );
 
             // when & then
             assertThatThrownBy(() -> authService.signin(wrongPasswordRequest))
@@ -195,14 +195,14 @@ class AuthServiceTest {
 
         @BeforeEach
         void setupLogout() {
-            SignupRequest request = SignupRequest.builder()
-                    .email("logout@test.com")
-                    .password("password")
-                    .name("로그아웃")
-                    .nickname("닉네임")
-                    .phoneNumber("01000000000")
-                    .userRole(UserRole.ROLE_USER)
-                    .build();
+            SignupRequest request = new SignupRequest(
+                    "logout@test.com",
+                    "password",
+                    "로그아웃",
+                    "닉네임",
+                    "01000000000",
+                    UserRole.ROLE_USER
+            );
 
             SignupResponse response = authService.signup(request);
             savedUser = userService.getUser(response.getId());

--- a/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/TokenServiceTest.java
@@ -3,7 +3,7 @@ package org.example.tablenow.domain.auth.service;
 import org.example.tablenow.domain.auth.dto.token.RefreshToken;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
-import org.example.tablenow.global.constant.SecurityConstants;
+import org.example.tablenow.global.constant.RedisKeyConstants;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
 import org.example.tablenow.global.util.JwtUtil;
@@ -99,7 +99,7 @@ class TokenServiceTest {
             // given
             willThrow(new RedisConnectionFailureException("Redis 연결 중 오류 발생"))
                     .given(ops)
-                    .set(startsWith(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
+                    .set(startsWith(RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
 
             // when & then
             assertThatThrownBy(() -> tokenService.createRefreshToken(user))
@@ -114,7 +114,7 @@ class TokenServiceTest {
 
             // then
             verify(redisTemplate.opsForValue())
-                    .set(startsWith(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
+                    .set(startsWith(RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX), eq(USER_ID.toString()), anyLong(), eq(TimeUnit.SECONDS));
             assertThat(refreshToken).isNotNull();
         }
     }
@@ -127,7 +127,7 @@ class TokenServiceTest {
         void Redis에_존재하지_않는_토큰으로_검증_시_예외처리() {
             // given
             String token = "invalid";
-            given(ops.get(SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token)).willReturn(null);
+            given(ops.get(RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + token)).willReturn(null);
 
             // when & then
             assertThatThrownBy(() -> tokenService.validateRefreshToken(token, USER_ID))
@@ -139,7 +139,7 @@ class TokenServiceTest {
         void Redis에_저장된_userId와_다른_사용자가_요청시_예외처리() {
             // given
             String token = UUID.randomUUID().toString();
-            String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
+            String redisKey = RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + token;
             given(ops.get(redisKey)).willReturn("999");
 
             // when & then
@@ -165,7 +165,7 @@ class TokenServiceTest {
         void Redis에_저장된_토큰으로_검증_시_RefreshToken_반환_성공() {
             // given
             String token = UUID.randomUUID().toString();
-            String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
+            String redisKey = RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + token;
             given(ops.get(redisKey)).willReturn(USER_ID.toString());
 
             // when
@@ -186,7 +186,7 @@ class TokenServiceTest {
         void Redis에서_리프레시_토큰_삭제_성공() {
             // given
             String token = UUID.randomUUID().toString();
-            String redisKey = SecurityConstants.REFRESH_TOKEN_KEY_PREFIX + token;
+            String redisKey = RedisKeyConstants.REFRESH_TOKEN_KEY_PREFIX + token;
 
             // when
             tokenService.deleteRefreshToken(token);


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #232 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] RequestDto에서 테스트용 @Builder 제거 후 @AllArgsConstructor로 대체
- [X] ResponseDto에서 @Builder 사용 시 @RequiredArgsConstructor 제거
- [X] 카카오/네이버 InfoResponse에 @NoArgsConstructor(access = PROTECTED) 추가하여 역직렬화만 허용
- [X] SecurityConstants에 있던 토큰 관련 키를 RedisKeyConstants로 이동
