### PR TITLE
[fix] Auth 도메인 테스트 코드 오류 수정

### DIFF
--- a/src/main/java/org/example/tablenow/domain/auth/oAuth/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/oAuth/kakao/KakaoUserInfoResponse.java
@@ -1,18 +1,17 @@
 package org.example.tablenow.domain.auth.oAuth.kakao;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class KakaoUserInfoResponse {
 
     private Long id;
     private KakaoAccount kakao_account;
 
     @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor
     public static class KakaoAccount {
         private String email;
         private String name;
@@ -20,7 +19,7 @@ public class KakaoUserInfoResponse {
         private Profile profile;
 
         @Getter
-        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        @NoArgsConstructor
         public static class Profile {
             private String nickname;
             private String profile_image_url;

--- a/src/main/java/org/example/tablenow/domain/auth/oAuth/naver/NaverUserInfoResponse.java
+++ b/src/main/java/org/example/tablenow/domain/auth/oAuth/naver/NaverUserInfoResponse.java
@@ -1,11 +1,10 @@
 package org.example.tablenow.domain.auth.oAuth.naver;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class NaverUserInfoResponse {
 
     private String resultcode;
@@ -13,7 +12,7 @@ public class NaverUserInfoResponse {
     private Response response;
 
     @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor
     public static class Response {
         private String id;
         private String name;

--- a/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/auth/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import org.example.tablenow.domain.auth.dto.response.SignupResponse;
 import org.example.tablenow.domain.auth.dto.response.TokenResponse;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
+import org.example.tablenow.domain.user.repository.UserRepository;
 import org.example.tablenow.domain.user.service.UserService;
 import org.example.tablenow.global.exception.ErrorCode;
 import org.example.tablenow.global.exception.HandledException;
@@ -37,13 +38,17 @@ class AuthServiceTest {
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private UserRepository userRepository;
+
     private SignupRequest signupRequest;
     private SigninRequest signinRequest;
 
     @BeforeEach
     void setUp() {
+        String uniqueEmail = "user" + System.nanoTime() + "@test.com";
         signupRequest = new SignupRequest(
-                "user@test.com",
+                uniqueEmail,
                 "password",
                 "이름",
                 "닉네임",
@@ -116,6 +121,7 @@ class AuthServiceTest {
             // given
             User savedUser = userService.getUser(signupResponse.getId());
             savedUser.deleteUser();
+            userRepository.save(savedUser); // dirty checking을 못해서 save 처리 추가
 
             // when & then
             assertThatThrownBy(() -> authService.signin(signinRequest))
@@ -195,8 +201,9 @@ class AuthServiceTest {
 
         @BeforeEach
         void setupLogout() {
+            String uniqueEmail = "logout" + System.nanoTime() + "@test.com";
             SignupRequest request = new SignupRequest(
-                    "logout@test.com",
+                    uniqueEmail,
                     "password",
                     "로그아웃",
                     "닉네임",


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #238 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [x] KakaoUserInfoResponse `@NoArgsConstructor(access = PROTECTED)` → `@NoArgsConstructor`
- [x] NaverUserInfoResponse `@NoArgsConstructor(access = PROTECTED)` → `@NoArgsConstructor`
- [x] 테스트에서 사용하는 이메일을 `System.nanoTime()` 기반으로 유니크하게 생성하도록 변경
- [x] `User.deleteUser()` 호출 후 변경사항이 반영되도록 `userRepository.save()` 호출


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- 테스트에서 동일한 이메일을 사용하는 경우 `이미 가입된 이메일입니다` 예외가 발생하여 테스트 충돌 발생
    → 모든 테스트에서 고정된 이메일을 사용하지 않도록 유니크한 이메일을 생성하여 독립적인 테스트 환경을 보장
- 로그인 테스트 중 `deleteUser()` 호출 후 변경사항이 DB에 반영되지 않는 문제 발생
   → soft delete 후 DB에 반영되지 않아 예외가 발생하지 않던 문제를 save() 호출로 해결
- 실제 애플리케이션에서는 정상 작동하지만, 테스트 코드에서 Kakao/NaverUserInfoResponse의 내부 클래스가 `@NoArgsConstructor(access = PROTECTED)`로 인해 Jackson 역직렬화에 실패함
   →  `@NoArgsConstructor`로 변경

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/b3ad490b-d669-47ad-8ead-16fdb46f4f2c)