### PR TITLE
[test] 리팩토링에 따른 이벤트 API 테스트코드 수정

### DIFF
--- a/src/test/java/org/example/tablenow/domain/event/EventJoinExecutorTest.java
+++ b/src/test/java/org/example/tablenow/domain/event/EventJoinExecutorTest.java
@@ -50,33 +50,42 @@ public class EventJoinExecutorTest {
     @InjectMocks
     private EventJoinExecutor eventJoinExecutor;
 
-    Long eventId = 1L;
-    Long userId = 1L;
-    String userIdStr = String.valueOf(userId);
-    String zsetKey = "event:join:" + eventId;
+    private Long eventId;
+    private Long userId;
+    private String userIdStr;
+    private String zsetKey;
+    private AuthUser authUser;
+    private Event event;
 
-    AuthUser authUser = new AuthUser(userId, "test@test.com", UserRole.ROLE_USER, "일반회원");
-
-    Store store;
-    Event event;
+    private final LocalDateTime baseTime = LocalDateTime.of(2025, 4, 30, 0, 0);
 
     @BeforeEach
     void setUp() {
-        store = Store.builder()
+        eventId = 1L;
+        userId = 1L;
+        userIdStr = userId.toString();
+        zsetKey = "event:join:" + eventId;
+
+        authUser = new AuthUser(userId, "test@test.com", UserRole.ROLE_USER, "일반회원");
+
+        Store store = Store.builder()
                 .id(100L)
                 .capacity(10)
                 .build();
 
-        EventRequestDto dto = EventRequestDto.builder()
-                .storeId(store.getId())
-                .openAt(LocalDateTime.now().minusDays(1))
-                .eventTime(LocalDateTime.now().plusDays(1))
-                .limitPeople(5)
-                .build();
+        EventRequestDto dto = new EventRequestDto(
+                store.getId(),
+                "content",
+                baseTime.minusDays(1),
+                baseTime.plusHours(10),
+                baseTime.plusHours(18),
+                5
+        );
 
         event = Event.create(store, dto);
         ReflectionTestUtils.setField(event, "id", eventId);
         ReflectionTestUtils.setField(event, "status", EventStatus.OPENED);
+
         lenient().when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
     }
 

--- a/src/test/java/org/example/tablenow/domain/event/EventJoinServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/event/EventJoinServiceTest.java
@@ -46,37 +46,36 @@ public class EventJoinServiceTest {
     @InjectMocks
     private EventJoinService eventJoinService;
 
-    Long eventId = 1L;
-    Long userId = 1L;
-    AuthUser authUser = new AuthUser(userId, "user@test.com", UserRole.ROLE_USER, "일반회원");
-    User user = User.fromAuthUser(authUser);
-
-    Store store;
-    Event event;
+    private Long eventId;
+    private AuthUser authUser;
+    private User user;
+    private Store store;
+    private Event event;
 
     @BeforeEach
     void setUp() {
+        eventId = 1L;
+        Long userId = 1L;
+        authUser = new AuthUser(userId, "user@test.com", UserRole.ROLE_USER, "일반회원");
+        user = User.fromAuthUser(authUser);
+
         store = Store.builder()
                 .id(100L)
                 .name("테스트 가게")
                 .capacity(10)
                 .build();
 
-        event = createEvent(eventId, EventStatus.OPENED);
-    }
-
-    private Event createEvent(Long id, EventStatus status) {
-        EventRequestDto dto = EventRequestDto.builder()
-                .storeId(store.getId())
-                .openAt(LocalDateTime.now().minusDays(1))
-                .eventTime(LocalDateTime.now().plusDays(1))
-                .limitPeople(10)
-                .build();
-
-        Event event = Event.create(store, dto);
-        ReflectionTestUtils.setField(event, "id", id);
-        ReflectionTestUtils.setField(event, "status", status);
-        return event;
+        EventRequestDto dto = new EventRequestDto(
+                store.getId(),
+                "content",
+                LocalDateTime.of(2025, 4, 29, 0, 0),
+                LocalDateTime.of(2025, 4, 30, 10, 0),
+                LocalDateTime.of(2025, 4, 30, 18, 0),
+                10
+        );
+        event = Event.create(store, dto);
+        ReflectionTestUtils.setField(event, "id", eventId);
+        ReflectionTestUtils.setField(event, "status", EventStatus.OPENED);
     }
 
     @Nested


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #225 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [x] 이벤트 서비스 테스트 전반 리팩토링
- [x] `setUp()` 정리로 공통 초기화 로직 통합
- [x] `baseTime` 도입하여 `LocalDateTime` 연산 방식 일관화
- [x] `createStore()`, `createEvent()` 유틸 메서드 활용으로 중복 제거


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- 각 테스트 클래스 간 상태 공유를 제거하여 독립적으로 동작하도록 개선했습니다.

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/b9407a79-ff48-48a4-a8c8-7cfd9dfbbead)