### PR TITLE
[fix] 이벤트 삭제/마감 시 Redis ZSET 제거 누락 수정

### DIFF
--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     EVENT_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 해당 이벤트에 참가하였습니다."),
     EVENT_FULL(HttpStatus.BAD_REQUEST, "이벤트 정원이 초과되었습니다."),
     EVENT_LOCK_TIMEOUT(HttpStatus.CONFLICT, "이벤트 신청 대기 중 시간이 초과되었습니다."),
+    EVENT_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 메시지를 직렬화하는 데 실패했습니다."),
 
     // NOTIFICATION
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림이 존재하지 않습니다."),


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #240

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 이벤트 삭제/마감 시 Redis ZSET(`event:open:zset`)에서 이벤트 제거 누락된 문제 수정
- [X] `removeEventOpenFromRedis()` 메서드로 제거 로직 공통화
- [X] `ErrorCode`에 `EVENT_SERIALIZATION_FAILED` 추가
- [X] 직렬화 실패 시 `HandledException(EVENT_SERIALIZATION_FAILED)`으로 예외 처리
- [X] dirty checking 오류로 명시적으로 `save()` 추가
- [X] Redis 저장 로직 `saveEventOpenToRedis()` 메서드로 분리


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- [dirty checking이 그저께부터 계속 안먹어서](https://www.notion.so/teamsparta/Dirty-Checking-1e42dc3ef51480c980fcd0cb9936c142?pvs=4) 일단 `save()`로 처리해놓았습니다. `save()` 없이도 되는지 확인 한 번만 부탁드립니다!
