### PR TITLE
[fix] 가게 ElasticSearch 인덱스 버그 수정

### DIFF
--- a/logstash/pipelines/logstash.conf
+++ b/logstash/pipelines/logstash.conf
@@ -5,7 +5,7 @@ input {
     jdbc_user => "${DB_USER_DATA}"
     jdbc_password => "${DB_PASSWORD_DATA}"
     jdbc_driver_library => "/usr/share/logstash/mysql-connector-j-9.1.0.jar"
-    statement => "SELECT * FROM store"
+    statement => "SELECT s.*, c.name AS category_name FROM store s JOIN category c ON s.category_id = c.id"
     jdbc_paging_enabled => true
     jdbc_page_size => 5000
   }

--- a/src/main/java/org/example/tablenow/domain/rating/service/RatingService.java
+++ b/src/main/java/org/example/tablenow/domain/rating/service/RatingService.java
@@ -9,6 +9,7 @@ import org.example.tablenow.domain.rating.entity.Rating;
 import org.example.tablenow.domain.rating.repository.RatingRepository;
 import org.example.tablenow.domain.reservation.service.ReservationService;
 import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.store.message.producer.StoreProducer;
 import org.example.tablenow.domain.store.service.StoreService;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.global.dto.AuthUser;
@@ -24,6 +25,7 @@ public class RatingService {
     private final RatingRepository ratingRepository;
     private final StoreService storeService;
     private final ReservationService reservationService;
+    private final StoreProducer storeProducer;
 
     @Transactional
     public RatingCreateResponseDto createRating(AuthUser authUser, Long storeId, RatingRequestDto requestDto) {
@@ -42,6 +44,7 @@ public class RatingService {
         Rating savedRating = ratingRepository.save(rating);
         store.applyRating(newRating);
 
+        storeProducer.publishStoreUpdate(store);
         return RatingCreateResponseDto.fromRating(savedRating);
     }
 
@@ -57,6 +60,7 @@ public class RatingService {
         rating.updateRating(newRating);
         store.updateRating(oldRating, newRating);
 
+        storeProducer.publishStoreUpdate(store);
         return RatingUpdateResponseDto.fromRating(rating);
     }
 
@@ -69,6 +73,7 @@ public class RatingService {
         store.removeRating(rating.getRating());
         ratingRepository.delete(rating);
 
+        storeProducer.publishStoreUpdate(store);
         return RatingDeleteResponseDto.fromRating(rating.getId());
     }
 

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreCreateResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreCreateResponseDto.java
@@ -8,6 +8,9 @@ import org.example.tablenow.domain.store.entity.Store;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_HH_MM;
+import static org.example.tablenow.global.constant.TimeConstants.TIME_YYYY_MM_DD_HH_MM_SS;
+
 @Getter
 public class StoreCreateResponseDto {
     private final Long storeId;
@@ -19,12 +22,12 @@ public class StoreCreateResponseDto {
     private final String address;
     private final String imageUrl;
     private final Integer capacity;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime startTime;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime endTime;
     private final Integer deposit;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime createdAt;
 
     @Builder

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreDocumentResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreDocumentResponseDto.java
@@ -9,6 +9,8 @@ import org.example.tablenow.domain.store.entity.StoreDocument;
 
 import java.io.Serializable;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_HH_MM;
+
 @Getter
 public class StoreDocumentResponseDto implements Serializable {
     private final Long storeId;
@@ -16,9 +18,9 @@ public class StoreDocumentResponseDto implements Serializable {
     private final Long categoryId;
     private final String categoryName;
     private final String imageUrl;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final String startTime;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final String endTime;
     private final Double rating;
     private final Integer ratingCount;

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreResponseDto.java
@@ -7,6 +7,8 @@ import org.example.tablenow.domain.store.entity.Store;
 
 import java.time.LocalTime;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_HH_MM;
+
 @Getter
 public class StoreResponseDto {
     private final Long storeId;
@@ -18,9 +20,9 @@ public class StoreResponseDto {
     private final String address;
     private final String imageUrl;
     private final Integer capacity;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime startTime;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime endTime;
     private final Integer deposit;
     private final Double rating;

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreSearchResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreSearchResponseDto.java
@@ -8,6 +8,8 @@ import org.example.tablenow.domain.store.entity.Store;
 import java.io.Serializable;
 import java.time.LocalTime;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_HH_MM;
+
 @Getter
 public class StoreSearchResponseDto implements Serializable {
     private final Long storeId;
@@ -15,9 +17,9 @@ public class StoreSearchResponseDto implements Serializable {
     private final Long categoryId;
     private final String categoryName;
     private final String imageUrl;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime startTime;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime endTime;
     private final Double rating;
     private final Integer ratingCount;

--- a/src/main/java/org/example/tablenow/domain/store/dto/response/StoreUpdateResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/store/dto/response/StoreUpdateResponseDto.java
@@ -8,6 +8,9 @@ import org.example.tablenow.domain.store.entity.Store;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_HH_MM;
+import static org.example.tablenow.global.constant.TimeConstants.TIME_YYYY_MM_DD_HH_MM_SS;
+
 @Getter
 public class StoreUpdateResponseDto {
     private final Long storeId;
@@ -19,12 +22,12 @@ public class StoreUpdateResponseDto {
     private final String address;
     private final String imageUrl;
     private final Integer capacity;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime startTime;
-    @JsonFormat(pattern = "HH:mm")
+    @JsonFormat(pattern = TIME_HH_MM)
     private final LocalTime endTime;
     private final Integer deposit;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime updatedAt;
 
     @Builder

--- a/src/main/java/org/example/tablenow/domain/store/entity/StoreDocument.java
+++ b/src/main/java/org/example/tablenow/domain/store/entity/StoreDocument.java
@@ -12,6 +12,12 @@ import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.example.tablenow.global.constant.TimeConstants.TIME_HH_MM;
+import static org.example.tablenow.global.constant.TimeConstants.ZONE_ID_ASIA_SEOUL;
+import static org.example.tablenow.global.util.TimeFormatUtil.isValidUtcIso8601;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -77,5 +83,19 @@ public class StoreDocument {
                 .categoryName(store.getCategoryName())
                 .deletedAt(store.getDeletedAt())
                 .build();
+    }
+
+    public void convertTimeFormat() {
+        this.startTime = convertUtcIsoToKstHHmm(this.startTime);
+        this.endTime = convertUtcIsoToKstHHmm(this.endTime);
+    }
+
+    private String convertUtcIsoToKstHHmm(String timeStr) {
+        if (isValidUtcIso8601(timeStr)) {
+            ZonedDateTime utcTime = ZonedDateTime.parse(timeStr);
+            ZonedDateTime seoulTime = utcTime.withZoneSameInstant(ZONE_ID_ASIA_SEOUL);
+            return seoulTime.format(DateTimeFormatter.ofPattern(TIME_HH_MM));
+        }
+        return timeStr;
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/message/consumer/StoreConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/consumer/StoreConsumer.java
@@ -1,13 +1,21 @@
 package org.example.tablenow.domain.store.message.consumer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.store.entity.StoreDocument;
-import org.example.tablenow.domain.store.message.dto.StoreEventDto;
 import org.example.tablenow.domain.store.repository.StoreElasticRepository;
 import org.example.tablenow.domain.store.service.StoreSearchService;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 import static org.example.tablenow.global.constant.RabbitConstant.*;
 
@@ -16,42 +24,90 @@ import static org.example.tablenow.global.constant.RabbitConstant.*;
 @RequiredArgsConstructor
 public class StoreConsumer {
 
+    private final RabbitTemplate rabbitTemplate;
     private final StoreElasticRepository storeElasticRepository;
     private final StoreSearchService storeSearchService;
+    private final ObjectMapper objectMapper;
+
+    private static final int MAX_RETRY_COUNT = 3;
 
     @RabbitListener(queues = STORE_CREATE_QUEUE)
-    public void handleCreate(StoreEventDto event) {
+    public void handleCreate(Message message) {
         try {
-            StoreDocument storeDocument = updateIndexAndGetStoreDocument(event);
+            StoreDocument storeDocument = updateIndexAndGetStoreDocument(message);
             storeSearchService.evictSearchCacheForNewStore(storeDocument);
         } catch (Exception e) {
-            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생", e);
+            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생 (create)", e);
+            throw new HandledException(ErrorCode.STORE_RABBIT_MQ_MESSAGE_FAILED);
         }
     }
 
     @RabbitListener(queues = STORE_UPDATE_QUEUE)
-    public void handleUpdate(StoreEventDto event) {
+    public void handleUpdate(Message message) {
         try {
-            StoreDocument storeDocument = updateIndexAndGetStoreDocument(event);
+            StoreDocument storeDocument = updateIndexAndGetStoreDocument(message);
             storeSearchService.evictSearchCacheByStoreId(storeDocument.getId());
         } catch (Exception e) {
-            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생", e);
+            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생 (update)", e);
+            throw new HandledException(ErrorCode.STORE_RABBIT_MQ_MESSAGE_FAILED);
         }
     }
 
     @RabbitListener(queues = STORE_DELETE_QUEUE)
-    public void handleDelete(Long storeId) {
+    public void handleDelete(Message message) {
         try {
+            Long storeId = objectMapper.readValue(message.getBody(), Long.class);
             storeElasticRepository.deleteStoreIndex(storeId);
             storeSearchService.evictSearchCacheByStoreId(storeId);
         } catch (Exception e) {
-            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생", e);
+            log.error("[StoreDocumentConsumer] MQ 처리 중 예외 발생 (delete)", e);
+            throw new HandledException(ErrorCode.STORE_RABBIT_MQ_MESSAGE_FAILED);
         }
     }
 
-    private StoreDocument updateIndexAndGetStoreDocument(StoreEventDto event) {
-        StoreDocument storeDocument = event.getStoreDocument();
-        storeElasticRepository.updateStoreIndex(event.getStoreDocument());
+    // DLQ Consumers
+    @RabbitListener(queues = STORE_CREATE_DLQ)
+    public void handleCreateDlq(Message message) {
+        sendRetryMessage(message, STORE_CREATE_QUEUE);
+    }
+
+    @RabbitListener(queues = STORE_UPDATE_DLQ)
+    public void handleUpdateDlq(Message message) {
+        sendRetryMessage(message, STORE_UPDATE_QUEUE);
+    }
+
+    @RabbitListener(queues = STORE_DELETE_DLQ)
+    public void handleDeleteDlq(Message message) {
+        sendRetryMessage(message, STORE_DELETE_QUEUE);
+    }
+
+    private void sendRetryMessage(Message message, String mainQueue) {
+        MessageProperties props = message.getMessageProperties();
+        Integer retryCount = (Integer) props.getHeaders().getOrDefault("x-retry-count", 0);
+
+        if (retryCount >= MAX_RETRY_COUNT) {
+            log.warn("DLQ 재시도 {}회 초과 → 관리자 확인 필요: {}", MAX_RETRY_COUNT, new String(message.getBody()));
+            return;
+        }
+
+        Message retryMessage = getRetryMessage(message, mainQueue, props, retryCount);
+        rabbitTemplate.convertAndSend(mainQueue, retryMessage);
+    }
+
+    private static Message getRetryMessage(Message message, String mainQueue, MessageProperties props, Integer retryCount) {
+        Message retryMessage = MessageBuilder
+                .withBody(message.getBody())
+                .copyHeaders(props.getHeaders())
+                .setHeader("x-retry-count", retryCount + 1)
+                .build();
+
+        log.warn("DLQ 메시지 재전송 ({}회): {}", retryCount + 1, mainQueue);
+        return retryMessage;
+    }
+
+    private StoreDocument updateIndexAndGetStoreDocument(Message message) throws IOException {
+        StoreDocument storeDocument = objectMapper.readValue(message.getBody(), StoreDocument.class);
+        storeElasticRepository.updateStoreIndex(storeDocument);
         return storeDocument;
     }
 }

--- a/src/main/java/org/example/tablenow/domain/store/message/producer/StoreProducer.java
+++ b/src/main/java/org/example/tablenow/domain/store/message/producer/StoreProducer.java
@@ -1,9 +1,15 @@
 package org.example.tablenow.domain.store.message.producer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.store.entity.Store;
-import org.example.tablenow.domain.store.message.dto.StoreEventDto;
+import org.example.tablenow.domain.store.entity.StoreDocument;
+import org.example.tablenow.global.exception.ErrorCode;
+import org.example.tablenow.global.exception.HandledException;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -17,21 +23,36 @@ import static org.example.tablenow.global.constant.RabbitConstant.*;
 @Async
 public class StoreProducer {
     private final RabbitTemplate rabbitTemplate;
+    private final ObjectMapper objectMapper;
 
     public void publishStoreCreate(Store store) {
-        StoreEventDto event = StoreEventDto.fromStore(store);
-        rabbitTemplate.convertAndSend(STORE_EXCHANGE, STORE_CREATE, event);
-        log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", STORE_CREATE, store.getId());
+        StoreDocument storeDocument = StoreDocument.fromStore(store);
+        sendMessage(storeDocument, STORE_CREATE, store.getId());
     }
 
     public void publishStoreUpdate(Store store) {
-        StoreEventDto event = StoreEventDto.fromStore(store);
-        rabbitTemplate.convertAndSend(STORE_EXCHANGE, STORE_UPDATE, event);
-        log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", STORE_UPDATE, store.getId());
+        StoreDocument storeDocument = StoreDocument.fromStore(store);
+        sendMessage(storeDocument, STORE_UPDATE, store.getId());
     }
 
     public void publishStoreDelete(Long storeId) {
-        rabbitTemplate.convertAndSend(STORE_EXCHANGE, STORE_DELETE, storeId);
-        log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", STORE_DELETE, storeId);
+        sendMessage(storeId, STORE_DELETE, storeId);
+    }
+
+    private void sendMessage(Object payload, String routingKey, Object logId) {
+        try {
+            byte[] body = objectMapper.writeValueAsBytes(payload);
+            Message message = MessageBuilder
+                    .withBody(body)
+                    .setContentType(MessageProperties.CONTENT_TYPE_JSON)
+                    .setHeader("x-retry-count", 0) // 초기 전송 시 retry-count 0
+                    .build();
+
+            rabbitTemplate.send(STORE_EXCHANGE, routingKey, message);
+            log.info("[StoreDocumentProducer] RabbitMQ {} 메시지 발행 : storeId={}", routingKey, logId);
+        } catch (Exception e) {
+            log.error("[StoreDocumentProducer] 메시지 직렬화 실패: {}", e.getMessage(), e);
+            throw new HandledException(ErrorCode.STORE_SERIALIZATION_FAILED);
+        }
     }
 }

--- a/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
@@ -24,8 +24,14 @@ public class RabbitConstant {
     public static final String STORE_CREATE_QUEUE = "store.create.queue";
     public static final String STORE_UPDATE_QUEUE = "store.update.queue";
     public static final String STORE_DELETE_QUEUE = "store.delete.queue";
+    public static final String STORE_DLX = "store.dlx";
+    public static final String STORE_CREATE_DLQ = "store.create.dlq";
+    public static final String STORE_UPDATE_DLQ = "store.update.dlq";
+    public static final String STORE_DELETE_DLQ = "store.delete.dlq";
 
     public static final String CHAT_EXCHANGE = "chat.exchange";
     public static final String CHAT_QUEUE = "chat.queue";
     public static final String CHAT_ROUTING_KEY = "chat.key";
+
+    public static final int TTL_MILLIS = 30000;
 }

--- a/src/main/java/org/example/tablenow/global/constant/TimeConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/TimeConstants.java
@@ -7,4 +7,7 @@ public final class TimeConstants {
 
     public static final String TIME_ZONE_ASIA_SEOUL = "Asia/Seoul";
     public static final ZoneId ZONE_ID_ASIA_SEOUL = ZoneId.of(TIME_ZONE_ASIA_SEOUL);
+
+    public static final String TIME_HH_MM = "HH:mm";
+    public static final String TIME_YYYY_MM_DD_HH_MM_SS = "yyyy-MM-dd HH:mm:ss";
 }

--- a/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/tablenow/global/exception/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     STORE_TABLE_CAPACITY_EXCEEDED(HttpStatus.BAD_REQUEST, "해당 가게의 하루 수용 가능한 테이블 수를 초과했습니다."),
     STORE_ELASTICSEARCH_QUERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Elasticsearch 쿼리가 실패했습니다."),
     STORE_ELASTICSEARCH_INDEX_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Elasticsearch 인덱스 처리에 실패했습니다"),
+    STORE_RABBIT_MQ_MESSAGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "가게 데이터 메시지 처리 실패했습니다."),
+    STORE_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "가게 메시지를 직렬화하는 데 실패했습니다."),
 
     // RATING
     RATING_NOT_FOUND(HttpStatus.NOT_FOUND, "평점이 존재하지 않습니다."),

--- a/src/main/java/org/example/tablenow/global/util/TimeFormatUtil.java
+++ b/src/main/java/org/example/tablenow/global/util/TimeFormatUtil.java
@@ -1,0 +1,23 @@
+package org.example.tablenow.global.util;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
+
+public class TimeFormatUtil {
+    private static final Pattern ISO_UTC_PATTERN = Pattern.compile(
+            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{3})?Z$"
+    );
+
+    public static boolean isValidUtcIso8601(String input) {
+        if (!ISO_UTC_PATTERN.matcher(input).matches()) {
+            return false;
+        }
+        try {
+            ZonedDateTime.parse(input);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/example/tablenow/domain/rating/service/RatingServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/rating/service/RatingServiceTest.java
@@ -8,6 +8,7 @@ import org.example.tablenow.domain.rating.entity.Rating;
 import org.example.tablenow.domain.rating.repository.RatingRepository;
 import org.example.tablenow.domain.reservation.service.ReservationService;
 import org.example.tablenow.domain.store.entity.Store;
+import org.example.tablenow.domain.store.message.producer.StoreProducer;
 import org.example.tablenow.domain.store.service.StoreService;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.enums.UserRole;
@@ -39,6 +40,8 @@ public class RatingServiceTest {
     private StoreService storeService;
     @Mock
     private ReservationService reservationService;
+    @Mock
+    private StoreProducer storeProducer;
     @InjectMocks
     private RatingService ratingService;
 
@@ -125,6 +128,7 @@ public class RatingServiceTest {
 
             // then
             verify(reservationService).validateCreateRating(anyLong(), anyLong());
+            verify(storeProducer).publishStoreUpdate(any(Store.class));
             assertAll(
                     () -> assertNotNull(response),
                     () -> assertEquals(response.getUserId(), userId),
@@ -206,6 +210,7 @@ public class RatingServiceTest {
             RatingUpdateResponseDto response = ratingService.updateRating(authUser, storeId, dto);
 
             // then
+            verify(storeProducer).publishStoreUpdate(any(Store.class));
             assertAll(
                     () -> assertNotNull(response),
                     () -> assertEquals(response.getUserId(), userId),
@@ -289,6 +294,7 @@ public class RatingServiceTest {
             RatingDeleteResponseDto response = ratingService.deleteRating(authUser, storeId);
 
             // then
+            verify(storeProducer).publishStoreUpdate(any(Store.class));
             assertAll(
                     () -> assertNotNull(response),
                     () -> assertEquals(response.getRatingId(), ratingId),

--- a/src/test/java/org/example/tablenow/domain/store/message/StoreConsumerTest.java
+++ b/src/test/java/org/example/tablenow/domain/store/message/StoreConsumerTest.java
@@ -1,0 +1,150 @@
+package org.example.tablenow.domain.store.message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.tablenow.domain.store.entity.StoreDocument;
+import org.example.tablenow.domain.store.message.consumer.StoreConsumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class StoreConsumerTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+    @InjectMocks
+    private StoreConsumer storeConsumer;
+
+    @Nested
+    class DLQ_테스트 {
+        private MessageProperties props = new MessageProperties();
+        private Message message;
+
+        @Test
+        void 가게_생성_최대_재시도_초과시_재전송_안함() throws JsonProcessingException {
+            // given
+            StoreDocument storeDocument = mock(StoreDocument.class);
+            byte[] body = new ObjectMapper().writeValueAsBytes(storeDocument);
+            message = MessageBuilder
+                    .withBody(body)
+                    .andProperties(props)
+                    .build();
+
+            props.setHeader("x-retry-count", 3);
+
+            // when
+            storeConsumer.handleCreateDlq(message);
+
+            // then
+            verify(rabbitTemplate, never()).convertAndSend(anyString(), any(Message.class));
+        }
+
+        @Test
+        void 가게_생성_메시지_재전송() throws JsonProcessingException {
+            // given
+            StoreDocument storeDocument = mock(StoreDocument.class);
+            byte[] body = new ObjectMapper().writeValueAsBytes(storeDocument);
+            message = MessageBuilder
+                    .withBody(body)
+                    .andProperties(props)
+                    .build();
+
+            props.setHeader("x-retry-count", 2);
+
+            // when
+            storeConsumer.handleCreateDlq(message);
+
+            // then
+            verify(rabbitTemplate).convertAndSend(anyString(), any(Message.class));
+        }
+
+        @Test
+        void 가게_수정_최대_재시도_초과시_재전송_안함() throws JsonProcessingException {
+            // given
+            StoreDocument storeDocument = mock(StoreDocument.class);
+            byte[] body = new ObjectMapper().writeValueAsBytes(storeDocument);
+            message = MessageBuilder
+                    .withBody(body)
+                    .andProperties(props)
+                    .build();
+
+            props.setHeader("x-retry-count", 3);
+
+            // when
+            storeConsumer.handleUpdateDlq(message);
+
+            // then
+            verify(rabbitTemplate, never()).convertAndSend(anyString(), any(Message.class));
+        }
+
+        @Test
+        void 가게_수정_메시지_재전송() throws JsonProcessingException {
+            // given
+            StoreDocument storeDocument = mock(StoreDocument.class);
+            byte[] body = new ObjectMapper().writeValueAsBytes(storeDocument);
+            message = MessageBuilder
+                    .withBody(body)
+                    .andProperties(props)
+                    .build();
+
+            props.setHeader("x-retry-count", 2);
+
+            // when
+            storeConsumer.handleUpdateDlq(message);
+
+            // then
+            verify(rabbitTemplate).convertAndSend(anyString(), any(Message.class));
+        }
+
+        @Test
+        void 가게_삭제_최대_재시도_초과시_재전송_안함() throws JsonProcessingException {
+            // given
+            Long storeId = 1L;
+            byte[] body = new ObjectMapper().writeValueAsBytes(storeId);
+            message = MessageBuilder
+                    .withBody(body)
+                    .andProperties(props)
+                    .build();
+
+            props.setHeader("x-retry-count", 3);
+
+            // when
+            storeConsumer.handleDeleteDlq(message);
+
+            // then
+            verify(rabbitTemplate, never()).convertAndSend(anyString(), any(Message.class));
+        }
+
+        @Test
+        void 가게_삭제_메시지_재전송() throws JsonProcessingException {
+            // given
+            Long storeId = 1L;
+            byte[] body = new ObjectMapper().writeValueAsBytes(storeId);
+            message = MessageBuilder
+                    .withBody(body)
+                    .andProperties(props)
+                    .build();
+
+            props.setHeader("x-retry-count", 2);
+
+            // when
+            storeConsumer.handleDeleteDlq(message);
+
+            // then
+            verify(rabbitTemplate).convertAndSend(anyString(), any(Message.class));
+        }
+    }
+}

--- a/src/test/java/org/example/tablenow/domain/store/service/StoreCreateTest.java
+++ b/src/test/java/org/example/tablenow/domain/store/service/StoreCreateTest.java
@@ -1,10 +1,10 @@
 package org.example.tablenow.domain.store.service;
 
 import org.example.tablenow.domain.store.dto.request.StoreCreateRequestDto;
-import org.junit.jupiter.api.Test;
+import org.example.tablenow.domain.store.utils.StoreJdbcRepository;
+import org.example.tablenow.domain.store.utils.StoreRandomCreator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/org/example/tablenow/domain/store/utils/StoreJdbcRepository.java
+++ b/src/test/java/org/example/tablenow/domain/store/utils/StoreJdbcRepository.java
@@ -1,4 +1,4 @@
-package org.example.tablenow.domain.store.service;
+package org.example.tablenow.domain.store.utils;
 
 import org.example.tablenow.domain.store.dto.request.StoreCreateRequestDto;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/test/java/org/example/tablenow/domain/store/utils/StoreRandomCreator.java
+++ b/src/test/java/org/example/tablenow/domain/store/utils/StoreRandomCreator.java
@@ -1,4 +1,4 @@
-package org.example.tablenow.domain.store.service;
+package org.example.tablenow.domain.store.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #248 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] `logstash.conf` 수정
- [X] 가게 검색 시 time 데이터 변환
`StoreDocument`, `StoreElasticRepository` 변환 코드 추가 / Time UTC -> Asia/Seoul

- [X] 시간 패턴 "HH:mm", 날짜 패턴 "yyyy-MM-dd HH:mm:ss" 상수화

- [X] 평점 수정 시 가게 인덱스, 캐시 동기화 -> 가게 변경 메시지 발행
- [X] 관련 테스트코드 수정 - 평점 테스트코드
- [X] 더미데이터 생성용 테스트코드 패키지 이동: service -> util


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
* Response 클래스에서 시간 패턴 "HH:mm", 
* 날짜 패턴 "yyyy-MM-dd HH:mm:ss" 상수가 필요한 경우 `TimeConstants`의 `TIME_HH_MM`, `TIME_YYYY_MM_DD_HH_MM_SS`로 사용 부탁드립니다.


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
* AS-IS: Logstash 로 DB 데이터 -> 인덱스 생성 후 조회 시 카테고리명, 시간 데이터 오류
![스크린샷 2025-05-01 오후 1 57 48](https://github.com/user-attachments/assets/135ce750-0a09-4c36-a553-20a2764551c5)

* TO-BE: 수정 후 카테고리명, 시간 데이터 정상 조회
![스크린샷 2025-05-01 오후 2 00 41](https://github.com/user-attachments/assets/28d888db-7540-4b27-8960-6ffad592ed7b)
