### PR TITLE
[refactor] Redis 락 테스트코드 tryLock 인자(2,2)로 수정하여 오류 해결 

### DIFF
--- a/src/main/java/org/example/tablenow/domain/notification/message/vacancy/service/VacancyRetryService.java
+++ b/src/main/java/org/example/tablenow/domain/notification/message/vacancy/service/VacancyRetryService.java
@@ -24,7 +24,7 @@ public class VacancyRetryService {
     private static final String RETRY_HEADER = "x-retry-count";
     private static final int MAX_RETRY_COUNT = 3;
 
-    public void process(Message message) {
+    public void  process(Message message) {
         try {
             VacancyEventDto event = parseMessage(message);
             int retryCount = extractRetryCount(message);

--- a/src/test/java/org/example/tablenow/domain/waitlist/service/WaitlistServiceTest.java
+++ b/src/test/java/org/example/tablenow/domain/waitlist/service/WaitlistServiceTest.java
@@ -176,7 +176,7 @@ class WaitlistServiceTest {
             String lockKey = String.format("lock:store:10:date:%s", requestDto.getWaitDate());
             RLock mockLock = mock(RLock.class);
             given(redissonClient.getLock(lockKey)).willReturn(mockLock);
-            given(mockLock.tryLock(2, 1, TimeUnit.SECONDS)).willReturn(true);
+            given(mockLock.tryLock(2, 2, TimeUnit.SECONDS)).willReturn(true);
             given(mockLock.isHeldByCurrentThread()).willReturn(true);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
@@ -206,7 +206,7 @@ class WaitlistServiceTest {
             String lockKey = String.format("lock:store:10:date:%s", requestDto.getWaitDate());
             RLock mockLock = mock(RLock.class);
             given(redissonClient.getLock(lockKey)).willReturn(mockLock);
-            given(mockLock.tryLock(2, 1, TimeUnit.SECONDS)).willReturn(false);
+            given(mockLock.tryLock(2, 2, TimeUnit.SECONDS)).willReturn(false);
 
             HandledException exception = assertThrows(HandledException.class, () ->
                 waitlistService.registerLockWaitlist(1L, requestDto)
@@ -225,7 +225,7 @@ class WaitlistServiceTest {
             String lockKey = String.format("lock:store:10:date:%s", requestDto.getWaitDate());
             RLock mockLock = mock(RLock.class);
             given(redissonClient.getLock(lockKey)).willReturn(mockLock);
-            given(mockLock.tryLock(2, 1, TimeUnit.SECONDS)).willThrow(new InterruptedException());
+            given(mockLock.tryLock(2, 2, TimeUnit.SECONDS)).willThrow(new InterruptedException());
 
             HandledException exception = assertThrows(HandledException.class, () ->
                 waitlistService.registerLockWaitlist(1L, requestDto)


### PR DESCRIPTION
## 🔗 Issue Number
close#258


## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 레디스락_획득_실패() → tryLock(2L, 2L, SECONDS)로 수정
- [X] 작업 내역레디스락_대기등록_성공() → tryLock(2L, 2L, SECONDS)로 수정
- [X] 레디스락_인터럽트_발생_예외() → tryLock(2L, 2L, SECONDS)로 수정
