### PR TITLE
[feat] 예약 리마인드 알림 DLQ 및 DLX 적용

### DIFF
--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderDlqReprocessor.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderDlqReprocessor.java
@@ -1,0 +1,44 @@
+package org.example.tablenow.domain.reservation.message.customer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.constant.RabbitConstant.RESERVATION_REMINDER_SEND_DLQ;
+import static org.example.tablenow.global.constant.RabbitConstant.RESERVATION_REMINDER_SEND_RETRY_EXCHANGE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReminderDlqReprocessor {
+    private final RabbitTemplate rabbitTemplate;
+    private static final int MAX_RETRY_COUNT = 3;
+
+    @RabbitListener(queues = RESERVATION_REMINDER_SEND_DLQ)
+    public void reprocess(Message message) {
+        MessageProperties props = message.getMessageProperties();
+        Integer retryCount = (Integer) props.getHeaders().getOrDefault("x-retry-count", 0);
+
+        if (retryCount >= MAX_RETRY_COUNT) {
+            log.error("[ReminderDlqReprocessor] 재시도 횟수 초과 → reservationId={}, message={}",
+                    props.getHeaders().get("reservationId"), new String(message.getBody()));
+            return;
+        }
+
+        // retryCount 증가 및 헤더 업데이트
+        props.setHeader("x-retry-count", retryCount + 1);
+
+        // Retry Exchange로 재전송 (TTL 큐 -> 메인 큐 자동 복귀)
+        rabbitTemplate.send(
+                RESERVATION_REMINDER_SEND_RETRY_EXCHANGE,
+                message
+        );
+
+        log.warn("[ReminderDlqReprocessor] DLQ 메시지 재전송 완료 → retryCount={}, message={}",
+                retryCount + 1, new String(message.getBody()));
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/customer/ReminderSendConsumer.java
@@ -8,6 +8,7 @@ import org.example.tablenow.domain.notification.service.NotificationService;
 import org.example.tablenow.domain.reservation.message.dto.ReminderMessage;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.service.UserService;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
@@ -53,6 +54,7 @@ public class ReminderSendConsumer {
 
         } catch (Exception e) {
             log.error("[ReminderSendConsumer][Notification] 알림 전송 실패 → userId={}, reservationId={}", user.getId(), message.getReservationId(), e);
+            throw new AmqpRejectAndDontRequeueException("[DLQ] 알림 전송 실패 → DLQ로 이동", e);
         }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderRegisterProducer.java
@@ -19,6 +19,7 @@ public class ReminderRegisterProducer {
     public void send(ReminderMessage message) {
         rabbitTemplate.convertAndSend(
                 RESERVATION_REMINDER_REGISTER_EXCHANGE,
+                "",
                 message
         );
 

--- a/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/message/producer/ReminderSendProducer.java
@@ -19,6 +19,7 @@ public class ReminderSendProducer {
     public void send(ReminderMessage message) {
         rabbitTemplate.convertAndSend(
                 RESERVATION_REMINDER_SEND_EXCHANGE,
+                "",
                 message
         );
 

--- a/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/example/tablenow/domain/reservation/service/ReservationService.java
@@ -90,6 +90,7 @@ public class ReservationService {
                 .build();
 
         Reservation savedReservation = reservationRepository.save(reservation);
+        reminderRegisterProducer.send(ReminderMessage.fromReservation(savedReservation));
         return ReservationResponseDto.fromReservation(savedReservation);
     }
 
@@ -101,6 +102,7 @@ public class ReservationService {
         validateUpdatableReservation(user, id, request, reservation);
         redisTemplate.opsForZSet().remove(REMINDER_ZSET_KEY, String.valueOf(id));
         reservation.updateReservedAt(request.getReservedAt());
+        reservationRepository.save(reservation);
         reminderRegisterProducer.send(ReminderMessage.fromReservation(reservation));
 
         return ReservationResponseDto.fromReservation(reservation);
@@ -134,6 +136,7 @@ public class ReservationService {
         storeService.validateStoreOwnerId(reservation.getStore(), user);
 
         reservation.updateStatus(request.getStatus());
+        reservationRepository.save(reservation);
 
         return ReservationStatusResponseDto.fromReservation(reservation);
     }
@@ -145,6 +148,7 @@ public class ReservationService {
         validateReservationOwner(reservation, user);
 
         reservation.tryCancel();
+        reservationRepository.save(reservation);
 
         vacancyProducer.sendVacancyEvent(
             reservation.getStore().getId(),

--- a/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
@@ -1,21 +1,39 @@
 package org.example.tablenow.global.constant;
 
 public class RabbitConstant {
-    public static final String VACANCY_EXCHANGE = "vacancy.direct";
-    public static final String VACANCY_QUEUE = "vacancy.queue";
-    public static final String VACANCY_ROUTING_KEY = "vacancy.key";
+    // 빈자리 관련 PREFIX
+    public static final String VACANCY_PREFIX = "vacancy";
 
-    public static final String VACANCY_DLX = "vacancy.dlx";
-    public static final String VACANCY_DLQ = "vacancy.dlq";
+    // 예약 관련 PREFIX
+    public static final String RESERVATION_PREFIX = "reservation";
+    public static final String RESERVATION_REMINDER_PREFIX = RESERVATION_PREFIX + ".reminder";
 
-    public static final String EVENT_OPEN_EXCHANGE = "event.open.fanout";
-    public static final String EVENT_OPEN_QUEUE = "event.open.queue";
+    // 이벤트 관련 PREFIX
+    public static final String EVENT_PREFIX = "event";
+    public static final String EVENT_OPEN_PREFIX = EVENT_PREFIX + ".open";
 
-    public static final String RESERVATION_REMINDER_REGISTER_EXCHANGE = "reservation.reminder.register.exchange";
-    public static final String RESERVATION_REMINDER_REGISTER_QUEUE = "reservation.reminder.register.queue";
+    // 빈자리 알림
+    public static final String VACANCY_EXCHANGE = VACANCY_PREFIX + ".direct";
+    public static final String VACANCY_QUEUE = VACANCY_PREFIX + ".queue";
+    public static final String VACANCY_ROUTING_KEY = VACANCY_PREFIX + ".key";
 
-    public static final String RESERVATION_REMINDER_SEND_EXCHANGE = "reservation.reminder.send.exchange";
-    public static final String RESERVATION_REMINDER_SEND_QUEUE = "reservation.reminder.send.queue";
+    public static final String VACANCY_DLX = VACANCY_PREFIX + ".dlx";
+    public static final String VACANCY_DLQ = VACANCY_PREFIX + ".dlq";
+
+    // 예약 리마인드 알림
+    public static final String RESERVATION_REMINDER_SEND_EXCHANGE = RESERVATION_REMINDER_PREFIX + ".send.exchange";
+    public static final String RESERVATION_REMINDER_SEND_QUEUE = RESERVATION_REMINDER_PREFIX + ".send.queue";
+    public static final String RESERVATION_REMINDER_SEND_DLX = RESERVATION_REMINDER_PREFIX + ".send.dlx";
+    public static final String RESERVATION_REMINDER_SEND_DLQ = RESERVATION_REMINDER_PREFIX + ".send.dlq";
+    public static final String RESERVATION_REMINDER_SEND_RETRY_QUEUE = RESERVATION_REMINDER_PREFIX + ".send.retry.queue";
+    public static final String RESERVATION_REMINDER_SEND_RETRY_EXCHANGE = RESERVATION_REMINDER_PREFIX + ".send.retry.exchange";
+
+    public static final String RESERVATION_REMINDER_REGISTER_EXCHANGE = RESERVATION_REMINDER_PREFIX + ".register.exchange";
+    public static final String RESERVATION_REMINDER_REGISTER_QUEUE = RESERVATION_REMINDER_PREFIX + ".register.queue";
+
+    // 이벤트 오픈 알림
+    public static final String EVENT_OPEN_EXCHANGE = EVENT_OPEN_PREFIX + ".fanout";
+    public static final String EVENT_OPEN_QUEUE = EVENT_OPEN_PREFIX + ".queue";
 
     public static final String STORE_EXCHANGE = "store.exchange";
     public static final String STORE_CREATE = "store.create";


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #249 

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] `RabbitConfig` DLQ 및 DLX 설정 추가
- [X] 라우팅키 자리에 빈 문자열 추가
- [X] 알림 발송 실패 시 `AmqpRejectAndDontRequeueException` 예외 추가
- [X] TTL 30초, 재시도 3회로 설정
- [X] `ReminderDlqReprocessor` 클래스 생성
- [X] `RabbitConstant` 정리 및 DLQ 관련 상수 추가
- [X] `ReservationService`에 dirty checking 오류로 명시적인 `save()` 추가

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- 테스트 시 재전송이 3번이 아닌 1번 실행되었습니다. 그러나 현재 배포가 급한 상황이므로 우선 merge 후 시간이 되면 수정해보도록 하겠습니다. 

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
![image](https://github.com/user-attachments/assets/86e28fc0-bd66-445e-949f-0e109d9ceea6)
