### PR TITLE
[feat] 정산 스케쥴러 Redisson Lock 적용

### DIFF
--- a/src/main/java/org/example/tablenow/domain/settlement/batch/schedule/SettlementScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/settlement/batch/schedule/SettlementScheduler.java
@@ -3,35 +3,66 @@ package org.example.tablenow.domain.settlement.batch.schedule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.tablenow.domain.settlement.batch.util.JobTimeUtil;
+import org.redisson.api.RedissonClient;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.redisson.api.RLock;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.example.tablenow.global.constant.RedisKeyConstants.SETTLEMENT_SCHEDULE_LOCK_KEY;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class SettlementSchedule {
+public class SettlementScheduler {
 
     private final JobLauncher jobLauncher;
     private final JobRegistry jobRegistry;
-
+    private final RedissonClient redissonClient;
+// git commit -m "feat(settlement): SettlementScheduler에 Redisson Lock 적용 #"
     // 정산 등록: 1시간마다
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runRegisterJob() throws Exception {
 
         log.info("정산 등록 Job 시작");
-        runJob("settlementRegisterJob", "register");
+
+        RLock lock = redissonClient.getLock(SETTLEMENT_SCHEDULE_LOCK_KEY);
+        lock.lock();
+
+        try {
+            runJob("settlementRegisterJob", "register");
+        } finally {
+            lock.unlock();
+        }
     }
 
-    // 정산 완료: 매일 자정
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    // 정산 완료: 매일 00:00:01
+    @Scheduled(cron = "1 0 0 * * *", zone = "Asia/Seoul")
     public void runCompleteJob() throws Exception {
 
-        log.info("정산 완료 Job 시작");
-        runJob("settlementCompleteJob", "complete");
+        log.info("정산 완료 Job 대기 중");
+
+        RLock lock = redissonClient.getLock(SETTLEMENT_SCHEDULE_LOCK_KEY);
+        boolean isLocked = false;
+
+        try {
+            isLocked = lock.tryLock(1, 10, TimeUnit.MINUTES);
+
+            if (!isLocked) {
+                log.warn("정산 완료 Job 락 획득 실패, 선행 Job이 아직 완료되지 않음(Job Skipped)");
+                return;
+            }
+
+            log.info("정산 완료 Job 시작");
+            runJob("settlementCompleteJob", "complete");
+        } finally {
+            lock.unlock();
+        }
     }
 
     private void runJob(String jobName, String type) throws Exception {

--- a/src/main/java/org/example/tablenow/domain/settlement/batch/schedule/SettlementScheduler.java
+++ b/src/main/java/org/example/tablenow/domain/settlement/batch/schedule/SettlementScheduler.java
@@ -24,7 +24,7 @@ public class SettlementScheduler {
     private final JobLauncher jobLauncher;
     private final JobRegistry jobRegistry;
     private final RedissonClient redissonClient;
-// git commit -m "feat(settlement): SettlementScheduler에 Redisson Lock 적용 #"
+
     // 정산 등록: 1시간마다
     @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runRegisterJob() throws Exception {

--- a/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
+++ b/src/main/java/org/example/tablenow/global/constant/RedisKeyConstants.java
@@ -19,5 +19,8 @@ public class RedisKeyConstants {
     public static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
     public static final String BLACKLIST_TOKEN_KEY_PREFIX = "blacklistToken:";
 
+    // 정산 관련
+    public static final String SETTLEMENT_SCHEDULE_LOCK_KEY = "settlement-schedule-lock";
+
     private RedisKeyConstants() {}
 }


### PR DESCRIPTION
## 🔗 Issue Number
close #262 


## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 정산 스케쥴러에 `Redisson Lock`을 적용


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
처음에 Scheduler에 적합하다고 알려진 `Scheduler Lock`을 적용하려고 했으나, `settlementRegisterJob`에서 lock을 선점하고 있는 경우에 `Scheduler Lock`의 기본 전략인 skip 때문에 `settlementCompleteJob`이 skip되는 문제가 있었습니다. `settlementCompleteJob`은 하루에 한 번 실행되는 job이기에 skip이 되면 안되기 때문에 Redisson Lock을 적용하여 `SettlementScheduler`를 구현하였습니다.

`settlementRegisterJob`이 lock을 선점하기 위해 `settlementCompleteJob`이 실행되는 시간을 00:00:01로 설정했고, `settlementRegisterJob`이 먼저 수행되면 `isLocked = lock.tryLock(1, 10, TimeUnit.MINUTES)`으로 `settlementCompleteJob`이 최대 1분까지 대기 후, lock을 잡으면 최대 10분까지 lock을 점유하도록 설정했습니다.


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
