### PR TITLE
[fix] 가게 데이터 생성 시 인덱스 키 삭제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ out/
 ### logstash
 logs/
 /src/main/resources/logback-spring.xml
+
+### copilot
+/copilot/*

--- a/src/main/java/org/example/tablenow/domain/store/service/StoreSearchService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/StoreSearchService.java
@@ -138,10 +138,10 @@ public class StoreSearchService {
         Set<String> tokens = storeTextAnalyzerService.analyzeText(STORE_INDEX, STORE_ANALYZER, storeName);
 
         String emptyKeyword = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", "");
-        keys.add(emptyKeyword);
+        keys.addAll(scanKeys(emptyKeyword));
 
         for (String token : tokens) {
-            String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", token + "*");
+            String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", "*" + token + "*");
             keys.addAll(scanKeys(pattern));
         }
 

--- a/src/main/java/org/example/tablenow/domain/store/service/StoreSearchService.java
+++ b/src/main/java/org/example/tablenow/domain/store/service/StoreSearchService.java
@@ -68,7 +68,6 @@ public class StoreSearchService {
     public void evictSearchCacheForNewStore(StoreDocument storeDocument) {
         Set<String> keysToDelete = new HashSet<>();
         keysToDelete.addAll(scanKeysByKeywordTokens(storeDocument.getName()));
-        keysToDelete.addAll(scanKeysByCategoryId(storeDocument.getCategoryId()));
 
         if (!keysToDelete.isEmpty()) {
             stringRedisTemplate.delete(keysToDelete);
@@ -138,17 +137,15 @@ public class StoreSearchService {
         Set<String> keys = new HashSet<>();
         Set<String> tokens = storeTextAnalyzerService.analyzeText(STORE_INDEX, STORE_ANALYZER, storeName);
 
+        String emptyKeyword = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", "");
+        keys.add(emptyKeyword);
+
         for (String token : tokens) {
-            String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", token);
+            String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "keyword", token + "*");
             keys.addAll(scanKeys(pattern));
         }
 
         return keys;
-    }
-
-    private Set<String> scanKeysByCategoryId(Long categoryId) {
-        String pattern = StoreKeyGenerator.generateStoreKeyByPattern(STORE_SEARCH_KEY, "categoryId", String.valueOf(categoryId));
-        return scanKeys(pattern);
     }
 
     private Set<String> scanKeys(String pattern) {

--- a/src/main/java/org/example/tablenow/domain/store/util/StoreKeyGenerator.java
+++ b/src/main/java/org/example/tablenow/domain/store/util/StoreKeyGenerator.java
@@ -19,7 +19,7 @@ public class StoreKeyGenerator {
     }
 
     public static String generateStoreKeyByPattern(String header, String parameter, String keyword) {
-        String key = String.format("*%s*%s=%s*", header, parameter, keyword);
+        String key = String.format("*%s*%s=%s", header, parameter, keyword);
         log.info("[Radis 패턴 생성] {}", key);
         return key;
     }


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #260

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
> 🤔 가게 생성 시 기존 캐시 삭제 이유: 이전 캐시를 불러올 경우 새로 추가된 가게가 포함되어 있지 않아 조회 불가능 
- `전체 캐시 삭제`: 캐시 히트율이 감소 캐시 실효성이 떨어짐 → 인덱스 재조회 : ES 부하 증가
- `조건 키 삭제`: 새로 추가된 가게가 포함될 수 있을 캐시 키를 예측하여 해당 키만 삭제
→ 성능과 데이터 정합성 균형 유지 가능

`AS-IS`: 조건 키 삭제 로직 중 키워드를 검색하지 않은 전체 검색(`*:keyword=`) 캐시가 누락 → 신규 가게를 전체 목록에서 찾을 수 없음

`TO-BE`: 
- 전체 검색(`*:keyword=`) 캐시 + 키워드 ngram 토큰 분해하여 키 탐색 및 삭제
- 카테고리 아이디 기준 조건 삭제 (키워드 조건에 포함되어 굳이 카테고리 기준으로 삭제할 필요가 없음)

- [X] evictSearchCacheForNewStore 로직 수정

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->


## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
