### PR TITLE
[feat] 이벤트 오픈 알림 DLQ / DLX 적용 및 기타 오류 수정

### DIFF
--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventJoinResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventJoinResponseDto.java
@@ -7,15 +7,17 @@ import org.example.tablenow.domain.event.entity.EventJoin;
 
 import java.time.LocalDateTime;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_YYYY_MM_DD_HH_MM_SS;
+
 @Getter
 public class EventJoinResponseDto {
     private final Long eventJoinId;
     private final Long eventId;
     private final Long storeId;
     private final String storeName;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime eventTime;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime joinedAt;
     private final String message;
 

--- a/src/main/java/org/example/tablenow/domain/event/dto/response/EventResponseDto.java
+++ b/src/main/java/org/example/tablenow/domain/event/dto/response/EventResponseDto.java
@@ -8,22 +8,24 @@ import org.example.tablenow.domain.event.enums.EventStatus;
 
 import java.time.LocalDateTime;
 
+import static org.example.tablenow.global.constant.TimeConstants.TIME_YYYY_MM_DD_HH_MM_SS;
+
 @Getter
 public class EventResponseDto {
     private final Long eventId;
     private final Long storeId;
     private final String storeName;
     private final String content;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime openAt;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime endAt;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime eventTime;
     private final int limitPeople;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime createdAt;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = TIME_YYYY_MM_DD_HH_MM_SS)
     private final LocalDateTime updatedAt;
     private final EventStatus status;
 

--- a/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenConsumer.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenConsumer.java
@@ -8,6 +8,7 @@ import org.example.tablenow.domain.notification.service.NotificationService;
 import org.example.tablenow.domain.user.entity.User;
 import org.example.tablenow.domain.user.service.UserService;
 import org.example.tablenow.domain.event.message.dto.EventOpenMessage;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
@@ -68,6 +69,7 @@ public class EventOpenConsumer {
 
         } catch (Exception e) {
             log.error("[EventOpenConsumer][Notification] 알림 전송 실패 → userId={}, eventId={}", user.getId(), message.getEventId(), e);
+            throw new AmqpRejectAndDontRequeueException("[DLQ] 알림 전송 실패 → DLQ로 이동", e);
         }
     }
 }

--- a/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenDlqReprocessor.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/consumer/EventOpenDlqReprocessor.java
@@ -1,0 +1,21 @@
+package org.example.tablenow.domain.event.message.consumer;
+
+import lombok.RequiredArgsConstructor;
+import org.example.tablenow.domain.event.service.EventOpenRetryService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.amqp.core.Message;
+
+import static org.example.tablenow.global.constant.RabbitConstant.EVENT_OPEN_DLQ;
+
+@Component
+@RequiredArgsConstructor
+public class EventOpenDlqReprocessor {
+
+    private final EventOpenRetryService eventOpenRetryService;
+
+    @RabbitListener(queues = EVENT_OPEN_DLQ)
+    public void reprocess(Message message) {
+        eventOpenRetryService.process(message);
+    }
+}

--- a/src/main/java/org/example/tablenow/domain/event/message/producer/EventOpenProducer.java
+++ b/src/main/java/org/example/tablenow/domain/event/message/producer/EventOpenProducer.java
@@ -2,11 +2,12 @@ package org.example.tablenow.domain.event.message.producer;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.tablenow.global.constant.RabbitConstant;
 import org.example.tablenow.domain.event.message.dto.EventOpenMessage;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.constant.RabbitConstant.EVENT_OPEN_EXCHANGE;
 
 @Slf4j
 @Component
@@ -17,7 +18,8 @@ public class EventOpenProducer {
 
     public void send(EventOpenMessage message) {
         rabbitTemplate.convertAndSend(
-                RabbitConstant.EVENT_OPEN_EXCHANGE,
+                EVENT_OPEN_EXCHANGE,
+                "",
                 message
         );
 

--- a/src/main/java/org/example/tablenow/domain/event/service/EventOpenRetryService.java
+++ b/src/main/java/org/example/tablenow/domain/event/service/EventOpenRetryService.java
@@ -1,0 +1,47 @@
+package org.example.tablenow.domain.event.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import static org.example.tablenow.global.constant.RabbitConstant.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventOpenRetryService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    private static final int MAX_RETRY_COUNT = 3;
+
+    public void process(Message message) {
+        MessageProperties props = message.getMessageProperties();
+        Integer retryCount = (Integer) props.getHeaders().getOrDefault(RETRY_HEADER, 0);
+
+        if (retryCount >= MAX_RETRY_COUNT) {
+            log.error("[EventOpentRetryService] 재시도 최대 횟수 초과 → messageId={}, retryCount={}",
+                    message.getMessageProperties().getMessageId(), retryCount);
+            return;
+        }
+
+        Message retryMessage = MessageBuilder
+                .withBody(message.getBody())
+                .copyProperties(props)
+                .setHeader(RETRY_HEADER, retryCount + 1)
+                .build();
+
+        rabbitTemplate.send(
+                EVENT_OPEN_RETRY_EXCHANGE,
+                EVENT_OPEN_RETRY_ROUTING_KEY,
+                retryMessage
+        );
+
+        log.info("[EventOpentRetryService] DLQ 메시지 재전송 완료 → retryCount={}, routingKey={}, message={}",
+                retryCount + 1, EVENT_OPEN_RETRY_ROUTING_KEY, new String(retryMessage.getBody()));
+    }
+}

--- a/src/main/java/org/example/tablenow/global/config/RabbitConfig.java
+++ b/src/main/java/org/example/tablenow/global/config/RabbitConfig.java
@@ -57,7 +57,10 @@ public class RabbitConfig {
     // 이벤트 오픈 Queue, Exchange, Binding
     @Bean
     public Queue eventOpenQueue() {
-        return new Queue(EVENT_OPEN_QUEUE, true);
+        return QueueBuilder.durable(EVENT_OPEN_QUEUE)
+                .withArgument("x-dead-letter-exchange", EVENT_OPEN_DLX)
+                .withArgument("x-dead-letter-routing-key", EVENT_OPEN_DLQ_ROUTING_KEY)
+                .build();
     }
 
     @Bean
@@ -68,6 +71,43 @@ public class RabbitConfig {
     @Bean
     public Binding eventOpenBinding() {
         return bindFanout(eventOpenQueue(), eventOpenExchange());
+    }
+
+    // 이벤트 오픈 DLX 및 DLQ 설정
+    @Bean
+    public DirectExchange eventOpenDlx() {
+        return new DirectExchange(EVENT_OPEN_DLX);
+    }
+
+    @Bean
+    public Queue eventOpenDlq() {
+        return buildDlqQueue(EVENT_OPEN_DLQ);
+    }
+
+    @Bean
+    public Binding eventOpenDlqBinding() {
+        return bind(eventOpenDlq(), eventOpenDlx(), EVENT_OPEN_DLQ_ROUTING_KEY);
+    }
+
+    // 이벤트 오픈 RetryQueue
+    @Bean
+    public Queue eventOpenRetryQueue() {
+        return QueueBuilder.durable(EVENT_OPEN_RETRY_QUEUE)
+                .withArgument("x-message-ttl", TTL_MILLIS)
+                .withArgument("x-dead-letter-exchange", EVENT_OPEN_EXCHANGE)
+                .build();
+    }
+
+    @Bean
+    public DirectExchange eventOpenRetryExchange() {
+        return new DirectExchange(EVENT_OPEN_RETRY_EXCHANGE);
+    }
+
+    @Bean
+    public Binding eventOpenRetryBinding() {
+        return BindingBuilder.bind(eventOpenRetryQueue())
+                .to(eventOpenRetryExchange())
+                .with(EVENT_OPEN_RETRY_ROUTING_KEY);
     }
 
     // 예약 리마인드 등록 Queue, Exchange, Binding
@@ -125,7 +165,7 @@ public class RabbitConfig {
     @Bean
     public Queue reminderSendRetryQueue() {
         return QueueBuilder.durable(RESERVATION_REMINDER_SEND_RETRY_QUEUE)
-                .withArgument("x-message-ttl", 30000)
+                .withArgument("x-message-ttl", TTL_MILLIS)
                 .withArgument("x-dead-letter-exchange", RESERVATION_REMINDER_SEND_EXCHANGE)
                 .build();
     }
@@ -171,18 +211,6 @@ public class RabbitConfig {
         return buildDlqQueue(STORE_DELETE_DLQ);
     }
 
-    private Queue buildMainQueue(String queueName, String dlqRoutingKey) {
-        return QueueBuilder.durable(queueName)
-                .withArgument("x-dead-letter-exchange", STORE_DLX)
-                .withArgument("x-dead-letter-routing-key", dlqRoutingKey)
-                .withArgument("x-message-ttl", TTL_MILLIS)
-                .build();
-    }
-
-    private Queue buildDlqQueue(String dlqName) {
-        return QueueBuilder.durable(dlqName).build();
-    }
-
     @Bean
     public DirectExchange storeExchange() {
         return new DirectExchange(STORE_EXCHANGE);
@@ -221,10 +249,6 @@ public class RabbitConfig {
     @Bean
     public Binding storeDeleteDlqBinding(Queue storeDeleteDlq, DirectExchange storeDlx) {
         return bind(storeDeleteDlq, storeDlx, STORE_DELETE_DLQ);
-    }
-
-    private Binding bind(Queue queue, DirectExchange exchange, String routingKey) {
-        return BindingBuilder.bind(queue).to(exchange).with(routingKey);
     }
 
     // 채팅 알림 Queue, Exchange, Binding
@@ -266,6 +290,22 @@ public class RabbitConfig {
         factory.setDefaultRequeueRejected(false);
         factory.setMessageConverter(jsonMessageConverter());
         return factory;
+    }
+
+    private Queue buildMainQueue(String queueName, String dlqRoutingKey) {
+        return QueueBuilder.durable(queueName)
+                .withArgument("x-dead-letter-exchange", STORE_DLX)
+                .withArgument("x-dead-letter-routing-key", dlqRoutingKey)
+                .withArgument("x-message-ttl", TTL_MILLIS)
+                .build();
+    }
+
+    private Queue buildDlqQueue(String dlqName) {
+        return QueueBuilder.durable(dlqName).build();
+    }
+
+    private Binding bind(Queue queue, DirectExchange exchange, String routingKey) {
+        return BindingBuilder.bind(queue).to(exchange).with(routingKey);
     }
 
     private Binding bindFanout(Queue queue, FanoutExchange exchange) {

--- a/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
+++ b/src/main/java/org/example/tablenow/global/constant/RabbitConstant.java
@@ -32,9 +32,18 @@ public class RabbitConstant {
     public static final String RESERVATION_REMINDER_REGISTER_QUEUE = RESERVATION_REMINDER_PREFIX + ".register.queue";
 
     // 이벤트 오픈 알림
-    public static final String EVENT_OPEN_EXCHANGE = EVENT_OPEN_PREFIX + ".fanout";
+    public static final String EVENT_OPEN_EXCHANGE = EVENT_OPEN_PREFIX + ".exchange";
     public static final String EVENT_OPEN_QUEUE = EVENT_OPEN_PREFIX + ".queue";
 
+    public static final String EVENT_OPEN_DLX = EVENT_OPEN_PREFIX + ".dlx";
+    public static final String EVENT_OPEN_DLQ = EVENT_OPEN_PREFIX + ".dlq";
+    public static final String EVENT_OPEN_DLQ_ROUTING_KEY = EVENT_OPEN_PREFIX + ".dlq.key";
+
+    public static final String EVENT_OPEN_RETRY_QUEUE = EVENT_OPEN_PREFIX + ".retry.queue";
+    public static final String EVENT_OPEN_RETRY_EXCHANGE = EVENT_OPEN_PREFIX + ".retry.exchange";
+    public static final String EVENT_OPEN_RETRY_ROUTING_KEY = EVENT_OPEN_PREFIX + ".retry.key";
+
+    // 가게
     public static final String STORE_EXCHANGE = "store.exchange";
     public static final String STORE_CREATE = "store.create";
     public static final String STORE_UPDATE = "store.update";
@@ -47,9 +56,12 @@ public class RabbitConstant {
     public static final String STORE_UPDATE_DLQ = "store.update.dlq";
     public static final String STORE_DELETE_DLQ = "store.delete.dlq";
 
+    // 채팅
     public static final String CHAT_EXCHANGE = "chat.exchange";
     public static final String CHAT_QUEUE = "chat.queue";
     public static final String CHAT_ROUTING_KEY = "chat.key";
 
+    // 공통
     public static final int TTL_MILLIS = 30000;
+    public static final String RETRY_HEADER = "x-retry-count";
 }


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #270

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 상수 추가 및 누락된 곳에 적용
- [X] `EventOpenConsumer`에서 알림 전송 실패 시 `AmqpRejectAndDontRequeueException` 예외 처리 추가
- [X] `RabbitConfig`에 이벤트 오픈 관련 Queue/Exchange/Binding 설정 추가
- [X] `EventOpenDlqReprocessor`, `EventOpenRetryService` 클래스 생성 및 재처리 흐름 구현
- [X] DLQ 진입 → RetryQueue 전송 → TTL 만료 후 FanoutExchange 재발행 흐름 구현
- [X] `EventOpenProducer` 라우팅 키 누락 문제 수정 (`""` 적용)

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
- **오류 발생 시 30초마다 자동 재전송되며, 최대 3회까지 재시도 후 중단됩니다.**
- Retry 흐름은 DLQ + TTL + 재전송 구조로 안정적으로 구성되었습니다.
- 예약 도메인에도 동일한 재처리 구조를 적용해 수정하겠습니다.

## 📸 스크린샷
<!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
- retryCount 3회 출력, 3회 도달 시 재전송 시도 중단 확인

![image](https://github.com/user-attachments/assets/958356d6-40a9-4b48-8f9d-df0874f94a08)
![image](https://github.com/user-attachments/assets/d939211b-68db-444e-81c1-22a02a9cb3d3)
![image](https://github.com/user-attachments/assets/a9554d2d-25fe-43e1-a941-c5d5b057469c)